### PR TITLE
Add spy metric sinks to allow easier integration testing of metrics

### DIFF
--- a/examples/spy-sink.rs
+++ b/examples/spy-sink.rs
@@ -1,0 +1,37 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// To the extent possible under law, the author(s) have dedicated all copyright and
+// related and neighboring rights to this file to the public domain worldwide.
+// This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication along with this
+// software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+// This example shows how you might make use of the "Spy" sinks in Cadence
+// which are meant for integration testing your application. They allow callers
+// to retain a reference to an underlying `Write` implementation that can then
+// be used to verify that Cadence wrote what you thought it was going to write.
+
+use cadence::prelude::*;
+use cadence::{StatsdClient, BufferedSpyMetricSink};
+use std::sync::{Mutex, Arc};
+
+fn main() {
+    let our_writer = Arc::new(Mutex::new(Vec::new()));
+
+    // Ensure that the sink is dropped, forcing a flush of all buffered metrics.
+    {
+        let sink = BufferedSpyMetricSink::with_capacity(our_writer.clone(), 16);
+        let metrics = StatsdClient::from_sink("example.prefix", sink);
+
+        metrics.count("example.counter", 1).unwrap();
+        metrics.gauge("example.gauge", 5).unwrap();
+        metrics.time("example.timer", 32).unwrap();
+        metrics.histogram("example.histogram", 22).unwrap();
+        metrics.meter("example.meter", 8).unwrap();
+        metrics.set("example.set", 43).unwrap();
+    }
+
+    let buffer = our_writer.lock().unwrap();
+    println!("Contents of wrapped buffer: {:?}", buffer);
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -41,13 +41,13 @@ where
 {
     /// Create a new buffered `MultiLineWriter` instance that suffixes
     /// each write with a newline character ('\n').
-    pub(crate) fn new(cap: usize, inner: T) -> MultiLineWriter<T> {
-        Self::with_ending(cap, inner, "\n")
+    pub(crate) fn new(inner: T, cap: usize) -> MultiLineWriter<T> {
+        Self::with_ending(inner, cap, "\n")
     }
 
     /// Create a new buffered `MultiLineWriter` instance that suffixes
     /// each write with the given line ending.
-    pub(crate) fn with_ending(cap: usize, inner: T, end: &str) -> MultiLineWriter<T> {
+    pub(crate) fn with_ending(inner: T, cap: usize, end: &str) -> MultiLineWriter<T> {
         MultiLineWriter {
             written: 0,
             capacity: cap,
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_write_needs_flush() {
-        let mut buffered = MultiLineWriter::new(16, vec![]);
+        let mut buffered = MultiLineWriter::new(vec![],16);
 
         let write1 = buffered.write("foo:1234|c".as_bytes()).unwrap();
         let written_after_write1 = buffered.get_ref().len();
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_write_no_flush() {
-        let mut buffered = MultiLineWriter::new(32, vec![]);
+        let mut buffered = MultiLineWriter::new(vec![],32);
 
         let write1 = buffered.write("abc:3|g".as_bytes()).unwrap();
         let written_after_write1 = buffered.get_ref().len();
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_write_bigger_than_buffer() {
-        let mut buffered = MultiLineWriter::new(16, vec![]);
+        let mut buffered = MultiLineWriter::new(vec![], 16);
 
         let write1 = buffered
             .write("some_really_long_metric:456|c".as_bytes())
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_buffer_write_equal_capacity() {
-        let mut buffered = MultiLineWriter::new(8, vec![]);
+        let mut buffered = MultiLineWriter::new(vec![],8);
 
         let bytes_written = buffered.write("foo:42|c".as_bytes()).unwrap();
         let written = str::from_utf8(&buffered.get_ref()).unwrap();
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_flush_still_buffered() {
-        let mut buffered = MultiLineWriter::new(32, vec![]);
+        let mut buffered = MultiLineWriter::new(vec![], 32);
 
         buffered.write("xyz".as_bytes()).unwrap();
         buffered.write("abc".as_bytes()).unwrap();
@@ -220,7 +220,7 @@ mod tests {
         // BufWriter it's using internally is flushed when it goes out
         // of scope and anything that was buffered gets written out.
         {
-            let mut writer = MultiLineWriter::new(32, &mut buf);
+            let mut writer = MultiLineWriter::new(&mut buf, 32);
             let _r = writer.write("something".as_bytes()).unwrap();
             assert_eq!(0, writer.get_ref().len());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ pub use self::client::{
 };
 
 pub use self::sinks::{
-    BufferedUdpMetricSink, MetricSink, NopMetricSink, QueuingMetricSink, UdpMetricSink,
+    BufferedSpyMetricSink, BufferedUdpMetricSink, MetricSink, NopMetricSink, QueuingMetricSink,  UdpMetricSink, SpyMetricSink,
 };
 
 pub use self::types::{

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -10,10 +10,12 @@
 
 mod core;
 mod queuing;
+mod spy;
 mod udp;
 
 pub use crate::sinks::core::{MetricSink, NopMetricSink};
 pub use crate::sinks::queuing::QueuingMetricSink;
+pub use crate::sinks::spy::{BufferedSpyMetricSink, SpyMetricSink};
 pub use crate::sinks::udp::{BufferedUdpMetricSink, UdpMetricSink};
 
 #[cfg(unix)]

--- a/src/sinks/spy.rs
+++ b/src/sinks/spy.rs
@@ -1,0 +1,199 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2020 Nick Pillitteri
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::io::MultiLineWriter;
+use crate::sinks::core::MetricSink;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::fmt::{self, Debug, Formatter};
+use std::panic::RefUnwindSafe;
+
+// Default size of the buffer for buffered metric sinks, picked for
+// consistency with the UDP implementation.
+const DEFAULT_BUFFER_SIZE: usize = 512;
+
+#[derive(Clone)]
+struct SpyWriter {
+    inner: Arc<Mutex<dyn Write + Send + RefUnwindSafe + 'static>>,
+}
+
+impl SpyWriter {
+    fn from(inner: Arc<Mutex<dyn Write + Send + RefUnwindSafe + 'static>>) -> Self {
+        SpyWriter { inner }
+    }
+}
+
+impl Write for SpyWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut writer = self.inner.lock().unwrap();
+        writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut writer = self.inner.lock().unwrap();
+        writer.flush()
+    }
+}
+
+/// `MetricSink` implementation that writes all metrics to a shared `Write`
+/// instance that callers retain a reference to.
+///
+/// This is not a general purpose sink, rather it's a sink meant for verifying
+/// metrics written during the course of integration tests. Due to the requirement
+/// that callers retain a shared reference to the underlying `Write` implementation,
+/// this sink uses more locking (mutexes) than other sinks in Cadence. Thus, it
+/// should not be used in production, only testing.
+///
+/// Each metric is sent to the underlying writer when the `.emit()` method is
+/// called, in the thread of the caller.
+pub struct SpyMetricSink {
+    writer: Mutex<SpyWriter>,
+}
+
+impl SpyMetricSink {
+    pub fn from(writer: Arc<Mutex<dyn Write + Send + RefUnwindSafe + 'static>>) -> Self {
+        SpyMetricSink {
+            writer: Mutex::new(SpyWriter::from(writer))
+        }
+    }
+}
+
+impl MetricSink for SpyMetricSink {
+    fn emit(&self, metric: &str) -> io::Result<usize> {
+        let mut writer = self.writer.lock().unwrap();
+        writer.write(metric.as_bytes())
+    }
+}
+
+impl Debug for SpyMetricSink {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "SpyMetricSink {{ Mutex {{ SpyWriter {{ ... }} }} }}")
+    }
+}
+
+/// `MetricSink` implementation that buffers metrics and writes them to a
+/// shared `Write` instance that callers retain a reference to.
+///
+/// This is not a general purpose sink, rather it's a sink meant for verifying
+/// metrics written during the course of integration tests. Due to the requirement
+/// that callers retain a shared reference to the underlying `Write` implementation,
+/// this sink uses more locking (mutexes) than other sinks in Cadence. Thus, it
+/// should not be used in production, only testing.
+///
+/// Metrics are line buffered, meaning that a trailing "\n" is added
+/// after each metric written to this sink. When the buffer is sufficiently
+/// full and a write is attempted, the contents of the buffer are flushed to
+/// the underlying writer and then the metric is written to the buffer. The
+/// buffer is also flushed when this sink is destroyed.
+///
+/// The default size of the buffer is 512 bytes. This is to be consistent with
+/// the default for the `BufferedUdpMetricSink`. The buffer size can be customized
+/// using the `with_capacity` method to create the sink if desired.
+///
+/// If a metric larger than the buffer is emitted, it will be written
+/// directly to the underlying writer, bypassing the buffer.
+///
+/// Note that since metrics are buffered until a certain size is reached, it's
+/// possible that they may sit in the buffer for a while for applications
+/// that do not emit metrics frequently or at a high volume. For these low-
+/// throughput use cases, it may make more sense to use the `SpyMetricSink`
+/// since it sends metrics immediately with no buffering.
+pub struct BufferedSpyMetricSink {
+    writer: Mutex<MultiLineWriter<SpyWriter>>,
+}
+
+impl BufferedSpyMetricSink {
+    pub fn from(writer: Arc<Mutex<dyn Write + Send + RefUnwindSafe + 'static>>) -> Self {
+        Self::with_capacity(writer, DEFAULT_BUFFER_SIZE)
+    }
+
+    pub fn with_capacity(writer: Arc<Mutex<dyn Write + Send + RefUnwindSafe + 'static>>, cap: usize) -> Self {
+        BufferedSpyMetricSink {
+            writer: Mutex::new(MultiLineWriter::new(
+                SpyWriter::from(writer),
+                cap,
+            ))
+        }
+    }
+}
+
+impl MetricSink for BufferedSpyMetricSink {
+    fn emit(&self, metric: &str) -> io::Result<usize> {
+        let mut writer = self.writer.lock().unwrap();
+        writer.write(metric.as_bytes())
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        let mut writer = self.writer.lock().unwrap();
+        writer.flush()
+    }
+}
+
+impl Debug for BufferedSpyMetricSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BufferedSpyMetricSink {{ Mutex {{ MultiLineWriter {{ SpyWriter {{ ... }} }} }} }}")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::{Arc, Mutex};
+    use super::{BufferedSpyMetricSink, MetricSink, SpyMetricSink};
+
+    // Get a copy of the contents of the shared writer and make sure to
+    // drop the lock before any assertions, otherwise the mutex becomes
+    // poisoned and results in obscure errors when trying to debug tests
+    #[inline]
+    fn copy_buffer(writer: Arc<Mutex<Vec<u8>>>) -> Vec<u8> {
+        writer.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn test_spy_metric_sink() {
+        let writer = Arc::new(Mutex::new(Vec::new()));
+        let sink = SpyMetricSink::from(writer.clone());
+        sink.emit("buz:1|c").unwrap();
+
+        let contents = copy_buffer(writer);
+        assert_eq!("buz:1|c".as_bytes(), contents.as_slice());
+    }
+
+    #[test]
+    fn test_buffered_spy_metric_sink() {
+        let writer = Arc::new(Mutex::new(Vec::new()));
+
+        // Make sure the sink is dropped before checking what was written
+        // to the buffer so that we know everything was flushed
+        {
+            let sink = BufferedSpyMetricSink::with_capacity(writer.clone(), 16);
+            sink.emit("foo:54|c").unwrap();
+            sink.emit("foo:67|c").unwrap();
+        }
+
+        let contents = copy_buffer(writer);
+        assert_eq!("foo:54|c\nfoo:67|c\n".as_bytes(), contents.as_slice());
+    }
+
+    #[test]
+    fn test_buffered_spy_metric_sink_flush() {
+        let writer = Arc::new(Mutex::new(Vec::new()));
+
+        // Set the capacity of the buffer such that it won't be flushed
+        // from a single write. Thus we can test the flush method.
+        let sink = BufferedSpyMetricSink::with_capacity(writer.clone(), 64);
+        sink.emit("foo:54|c").unwrap();
+        sink.emit("foo:67|c").unwrap();
+        let flush = sink.flush();
+
+        let contents = copy_buffer(writer);
+        assert_eq!("foo:54|c\nfoo:67|c\n".as_bytes(), contents.as_slice());
+        assert!(flush.is_ok());
+    }
+}

--- a/src/sinks/udp.rs
+++ b/src/sinks/udp.rs
@@ -244,8 +244,8 @@ impl BufferedUdpMetricSink {
         let addr = get_addr(sink_addr)?;
         Ok(BufferedUdpMetricSink {
             buffer: Mutex::new(MultiLineWriter::new(
-                cap,
                 UdpWriteAdapter::new(addr, socket),
+                cap,
             )),
         })
     }
@@ -310,11 +310,11 @@ mod tests {
     }
 
     #[test]
-    fn test_buffered_udp_metric_sink_flus() {
+    fn test_buffered_udp_metric_sink_flush() {
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         // Set the capacity of the buffer such that it won't be flushed
         // from a single write. Thus we can test the flush method.
-        let sink = BufferedUdpMetricSink::with_capacity("127.0.0.1:8125", socket, 16).unwrap();
+        let sink = BufferedUdpMetricSink::with_capacity("127.0.0.1:8125", socket, 64).unwrap();
 
         // Note that we're including an extra byte in the expected
         // number written since each metric is followed by a '\n' at

--- a/src/sinks/unix.rs
+++ b/src/sinks/unix.rs
@@ -204,8 +204,8 @@ impl BufferedUnixMetricSink {
     {
         BufferedUnixMetricSink {
             buffer: Mutex::new(MultiLineWriter::new(
-                cap,
                 UnixWriteAdapter::new(socket, path),
+                cap,
             )),
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -230,20 +230,20 @@ impl Drop for UnixServerHarness {
 /// `MetricSink` so that the caller can keep a reference to it (useful
 /// for testing the `QueuingMetricSink` so that we can inspect the
 /// number of pending metrics and the like).
-pub struct SpyMetricSink {
+pub struct DelegatingMetricSink {
     delegate: Arc<dyn MetricSink + Send + Sync + RefUnwindSafe>,
 }
 
-impl SpyMetricSink {
+impl DelegatingMetricSink {
     pub fn new<S>(delegate: Arc<S>) -> Self
     where
         S: MetricSink + Send + Sync + RefUnwindSafe + 'static,
     {
-        SpyMetricSink { delegate }
+        DelegatingMetricSink { delegate }
     }
 }
 
-impl MetricSink for SpyMetricSink {
+impl MetricSink for DelegatingMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
         self.delegate.emit(metric)
     }

--- a/tests/spy.rs
+++ b/tests/spy.rs
@@ -1,0 +1,43 @@
+use cadence::{BufferedSpyMetricSink, SpyMetricSink, StatsdClient};
+use std::sync::{Arc, Mutex};
+
+mod utils;
+use utils::{run_arc_threaded_test, NUM_ITERATIONS, NUM_THREADS};
+
+fn new_spy_client(prefix: &str) -> StatsdClient {
+    let writer = Arc::new(Mutex::new(Vec::new()));
+    let sink = SpyMetricSink::from(writer.clone());
+    StatsdClient::from_sink(prefix, sink)
+}
+
+fn new_buffered_spy_client(prefix: &str) -> StatsdClient {
+    let writer = Arc::new(Mutex::new(Vec::new()));
+    let sink = BufferedSpyMetricSink::from(writer.clone());
+    StatsdClient::from_sink(prefix, sink)
+}
+
+#[test]
+fn test_statsd_client_spy_sink_single_threaded() {
+    let client = new_spy_client("cadence");
+    run_arc_threaded_test(client, 1, 1);
+}
+
+#[test]
+fn test_statsd_client_buffered_spy_sink_single_threaded() {
+    let client = new_buffered_spy_client("cadence");
+    run_arc_threaded_test(client, 1, 1);
+}
+
+#[ignore]
+#[test]
+fn test_statsd_client_spy_sink_many_threaded() {
+    let client = new_spy_client("cadence");
+    run_arc_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
+}
+
+#[ignore]
+#[test]
+fn test_statsd_client_buffered_spy_sink_many_threaded() {
+    let client = new_buffered_spy_client("cadence");
+    run_arc_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use cadence::prelude::*;
 use cadence::StatsdClient;
 
-pub const NUM_THREADS: u64 = 100;
-pub const NUM_ITERATIONS: u64 = 1_000;
+pub const NUM_THREADS: u64 = 10;
+pub const NUM_ITERATIONS: u64 = 1000;
 
 pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations: u64) {
     let shared_client = Arc::new(client);
@@ -22,6 +22,7 @@ pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations:
                     local_client.gauge("some.gauge", i).unwrap();
                     local_client.meter("some.meter", i).unwrap();
                     local_client.histogram("some.histogram", i).unwrap();
+                    local_client.set("some.set", i as i64).unwrap();
                     thread::sleep(Duration::from_millis(1));
                 }
             })


### PR DESCRIPTION
Add `SpyMetricSink` and `BufferedSpyMetricSink` which both write metrics
to a shared `Write` implementation to allow callers to verify the metrics
being written. These are not general purpose sinks but rather meant for
testing only.

Fixes #103

/cc @jrconlin 