### PR TITLE
Add methods to `Gauged` trait for f64 values

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -123,6 +123,11 @@ fn test_benchmark_new_gauge_obj(b: &mut Bencher) {
 }
 
 #[bench]
+fn test_benchmark_new_gauge_f64_obj(b: &mut Bencher) {
+    b.iter(|| Gauge::new_f64("prefix", "some.gauge", 5.5));
+}
+
+#[bench]
 fn test_benchmark_new_meter_obj(b: &mut Bencher) {
     b.iter(|| Meter::new("prefix", "some.meter", 5));
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,10 +15,11 @@ use std::fmt::{self, Write};
 use std::marker::PhantomData;
 
 /// Uniform holder for values that knows how to display itself
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 enum MetricValue {
     Signed(i64),
     Unsigned(u64),
+    Float(f64),
 }
 
 impl fmt::Display for MetricValue {
@@ -26,12 +27,13 @@ impl fmt::Display for MetricValue {
         match *self {
             MetricValue::Signed(i) => i.fmt(f),
             MetricValue::Unsigned(i) => i.fmt(f),
+            MetricValue::Float(i) => i.fmt(f),
         }
     }
 }
 
 /// Type of metric that knows how to display itself
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 enum MetricType {
     Counter,
     Timer,
@@ -54,7 +56,7 @@ impl fmt::Display for MetricType {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct MetricFormatter<'a, T>
 where
     T: Metric + From<String>,
@@ -83,6 +85,10 @@ where
 
     pub(crate) fn gauge(prefix: &'a str, key: &'a str, val: u64) -> Self {
         Self::from_u64(prefix, key, val, MetricType::Gauge)
+    }
+
+    pub(crate) fn gauge_f64(prefix: &'a str, key: &'a str, val: f64) -> Self {
+        Self::from_f64(prefix, key, val, MetricType::Gauge)
     }
 
     pub(crate) fn meter(prefix: &'a str, key: &'a str, val: u64) -> Self {
@@ -114,6 +120,17 @@ where
             key,
             type_,
             val: MetricValue::Signed(val),
+            metric: PhantomData,
+            tags: None,
+        }
+    }
+
+    fn from_f64(prefix: &'a str, key: &'a str, val: f64, type_: MetricType) -> Self {
+        MetricFormatter {
+            prefix,
+            key,
+            type_,
+            val: MetricValue::Float(val),
             metric: PhantomData,
             tags: None,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,10 @@ impl Gauge {
     pub fn new(prefix: &str, key: &str, value: u64) -> Gauge {
         MetricFormatter::gauge(prefix, key, value).build()
     }
+
+    pub fn new_f64(prefix: &str, key: &str, value: f64) -> Gauge {
+        MetricFormatter::gauge_f64(prefix, key, value).build()
+    }
 }
 
 impl From<String> for Gauge {

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -58,6 +58,13 @@ fn test_statsd_client_gauge() {
 }
 
 #[test]
+fn test_statsd_client_gauge_f64() {
+    let client = new_nop_client("client.test");
+    let expected = Gauge::new_f64("client.test.", "gauge.key", 5.5);
+    assert_eq!(expected, client.gauge_f64("gauge.key", 5.5).unwrap());
+}
+
+#[test]
 fn test_statsd_client_mark() {
     let client = new_nop_client("client.test");
     let expected = Meter::new("client.test.", "meter.key", 1);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -20,6 +20,7 @@ pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations:
                     local_client.count("some.counter", i as i64).unwrap();
                     local_client.time("some.timer", i).unwrap();
                     local_client.gauge("some.gauge", i).unwrap();
+                    local_client.gauge_f64("some.gauge", i as f64).unwrap();
                     local_client.meter("some.meter", i).unwrap();
                     local_client.histogram("some.histogram", i).unwrap();
                     local_client.set("some.set", i as i64).unwrap();


### PR DESCRIPTION
Many statsd client implementations support floating point values for
gauges (as well as integer values) so we should as well. A survey of
several other clients indicates that gauges are the only type we're
obviously out of alignment on (compared to counters, timers, etc).

I ended up taking the simple approach here and just adding a new `_f64`
method to the existing `Gauged` trait instead of doing something more
clever making all the traits generic or something like that.

/cc @craftytrickster

Fixes #106