### PR TITLE
Add support for distribution metric type

### DIFF
--- a/cadence-macros/examples/production-setup.rs
+++ b/cadence-macros/examples/production-setup.rs
@@ -8,7 +8,7 @@
 // software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 use cadence::{BufferedUdpMetricSink, QueuingMetricSink, StatsdClient, DEFAULT_PORT};
-use cadence_macros::{statsd_count, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
+use cadence_macros::{statsd_count, statsd_distribution, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
 use std::net::UdpSocket;
 
 fn main() {
@@ -23,5 +23,6 @@ fn main() {
     statsd_time!("some.timer", 1, "tag" => "val");
     statsd_meter!("some.meter", 1, "tag" => "val");
     statsd_histogram!("some.histogram", 1, "tag" => "val");
+    statsd_distribution!("some.distribution", 1, "tag" => "val");
     statsd_set!("some.set", 1, "tag" => "val");
 }

--- a/cadence-macros/examples/simple-setup.rs
+++ b/cadence-macros/examples/simple-setup.rs
@@ -8,7 +8,7 @@
 // software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
-use cadence_macros::{statsd_count, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
+use cadence_macros::{statsd_count, statsd_distribution, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
 use std::net::UdpSocket;
 
 fn main() {
@@ -22,5 +22,6 @@ fn main() {
     statsd_time!("some.timer", 1, "tag" => "val");
     statsd_meter!("some.meter", 1, "tag" => "val");
     statsd_histogram!("some.histogram", 1, "tag" => "val");
+    statsd_distribution!("some.distribution", 1, "tag" => "val");
     statsd_set!("some.set", 1, "tag" => "val");
 }

--- a/cadence-macros/tests/lib.rs
+++ b/cadence-macros/tests/lib.rs
@@ -1,5 +1,5 @@
 use cadence::{SpyMetricSink, StatsdClient};
-use cadence_macros::{statsd_count, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
+use cadence_macros::{statsd_count, statsd_distribution, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time};
 use std::io;
 use std::sync::{Arc, Mutex, Once};
 
@@ -125,6 +125,17 @@ fn test_statsd_histogram() {
     let storage = get_default_storage();
     assert!(storage.contains(&"my.prefix.some.histogram:223|h".to_owned()));
     assert!(storage.contains(&"my.prefix.some.histogram:223|h|#method:auth,result:error".to_owned()));
+}
+
+#[test]
+fn test_statsd_distribution() {
+    init_default_client();
+    statsd_distribution!("some.distribution", 223);
+    statsd_distribution!("some.distribution", 223, "method" => "auth", "result" => "error");
+
+    let storage = get_default_storage();
+    assert!(storage.contains(&"my.prefix.some.distribution:223|d".to_owned()));
+    assert!(storage.contains(&"my.prefix.some.distribution:223|d|#method:auth,result:error".to_owned()));
 }
 
 #[test]

--- a/cadence/examples/tag-view.rs
+++ b/cadence/examples/tag-view.rs
@@ -145,15 +145,6 @@ impl Distributed for MetricTagDecorator {
         let builder = self.client.distribution_with_tags(key, value);
         self.copy_tags_to_builder(builder)
     }
-
-    fn distribution_duration_with_tags<'a>(
-        &'a self,
-        key: &'a str,
-        duration: Duration,
-    ) -> MetricBuilder<'_, '_, Distribution> {
-        let builder = self.client.distribution_duration_with_tags(key, duration);
-        self.copy_tags_to_builder(builder)
-    }
 }
 
 impl Setted for MetricTagDecorator {

--- a/cadence/examples/tag-view.rs
+++ b/cadence/examples/tag-view.rs
@@ -15,8 +15,8 @@
 
 use cadence::prelude::*;
 use cadence::{
-    Counted, Counter, Gauge, Gauged, Histogram, Histogrammed, Meter, Metered, Metric, MetricBuilder, MetricSink, Set,
-    Setted, StatsdClient, Timed, Timer,
+    Counted, Counter, Distribution, Distributed, Gauge, Gauged, Histogram, Histogrammed, Meter, Metered, Metric, MetricBuilder,
+    MetricSink, Set, Setted, StatsdClient, Timed, Timer,
 };
 use std::fmt;
 use std::io;
@@ -136,6 +136,22 @@ impl Histogrammed for MetricTagDecorator {
         duration: Duration,
     ) -> MetricBuilder<'_, '_, Histogram> {
         let builder = self.client.histogram_duration_with_tags(key, duration);
+        self.copy_tags_to_builder(builder)
+    }
+}
+
+impl Distributed for MetricTagDecorator {
+    fn distribution_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Distribution> {
+        let builder = self.client.distribution_with_tags(key, value);
+        self.copy_tags_to_builder(builder)
+    }
+
+    fn distribution_duration_with_tags<'a>(
+        &'a self,
+        key: &'a str,
+        duration: Duration,
+    ) -> MetricBuilder<'_, '_, Distribution> {
+        let builder = self.client.distribution_duration_with_tags(key, duration);
         self.copy_tags_to_builder(builder)
     }
 }

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -41,6 +41,7 @@ enum MetricType {
     Meter,
     Histogram,
     Set,
+    Distribution,
 }
 
 impl fmt::Display for MetricType {
@@ -52,6 +53,7 @@ impl fmt::Display for MetricType {
             MetricType::Meter => "m".fmt(f),
             MetricType::Histogram => "h".fmt(f),
             MetricType::Set => "s".fmt(f),
+            MetricType::Distribution => "d".fmt(f),
         }
     }
 }
@@ -97,6 +99,10 @@ where
 
     pub(crate) fn histogram(prefix: &'a str, key: &'a str, val: u64) -> Self {
         Self::from_u64(prefix, key, val, MetricType::Histogram)
+    }
+
+    pub(crate) fn distribution(prefix: &'a str, key: &'a str, val: u64) -> Self {
+        Self::from_u64(prefix, key, val, MetricType::Distribution)
     }
 
     pub(crate) fn set(prefix: &'a str, key: &'a str, val: i64) -> Self {

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -219,8 +219,8 @@ pub trait Histogrammed {
 /// instrument logical objects, like services, independently from the underlying
 /// hosts.
 ///
-/// See the [Datadog docs](https://github.com/b/statsd_spec) for more
-/// information.
+/// See the [Datadog docs](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition)
+/// for more information.
 ///
 /// Note that tags and distributions are a
 /// [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) extension to

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -234,27 +234,6 @@ pub trait Distributed {
     /// Record a single distribution value with the given key and return a
     /// `MetricBuilder` that can be used to add tags to the metric.
     fn distribution_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Distribution>;
-
-    /// Record a single distribution value with the given key.
-    ///
-    /// The duration will be converted to nanoseconds. If the duration
-    /// cannot be represented as a `u64` an error will be returned. Note
-    /// that distributions are an extension to Statsd, you'll need to check
-    /// if they are supported by your server and considered times.
-    fn distribution_duration(&self, key: &str, duration: Duration) -> MetricResult<Distribution> {
-        self.distribution_duration_with_tags(key, duration).try_send()
-    }
-
-    /// Record a single distribution value with the given key and return a
-    /// `MetricBuilder` that can be used to add tags to the metric.
-    ///
-    /// The duration will be converted to nanoseconds. If the duration cannot
-    /// be represented as a `u64` an error will be deferred and returned when
-    /// `MetricBuilder::try_send()` is called. Note that distributions are an
-    /// extension to Statsd, you'll need to check if they are supported by
-    /// your server and considered times.
-    fn distribution_duration_with_tags<'a>(&'a self, key: &'a str, duration: Duration)
-        -> MetricBuilder<'_, '_, Distribution>;
 }
 
 /// Trait for recording set values.
@@ -833,19 +812,6 @@ impl Distributed for StatsdClient {
         let fmt = MetricFormatter::distribution(&self.prefix, key, value);
         MetricBuilder::new(fmt, self)
     }
-
-    fn distribution_duration_with_tags<'a>(
-        &'a self,
-        key: &'a str,
-        duration: Duration,
-    ) -> MetricBuilder<'_, '_, Distribution> {
-        let as_nanos = duration.as_nanos();
-        if as_nanos > u64::MAX as u128 {
-            MetricBuilder::from_error(MetricError::from((ErrorKind::InvalidInput, "u64 overflow")), self)
-        } else {
-            self.distribution_with_tags(key, as_nanos as u64)
-        }
-    }
 }
 
 impl Setted for StatsdClient {
@@ -1004,46 +970,6 @@ mod tests {
             "prefix.some.distr:27|d|#host:www03.example.com,rc1",
             res.unwrap().as_metric_str()
         );
-    }
-
-    #[test]
-    fn test_statsd_client_distribution_duration() {
-        let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client.distribution_duration("key", Duration::from_nanos(210));
-
-        assert_eq!("prefix.key:210|d", res.unwrap().as_metric_str());
-    }
-
-    #[test]
-    fn test_statsd_client_distribution_duration_with_overflow() {
-        let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client.distribution_duration("key", Duration::from_secs(u64::MAX));
-
-        assert_eq!(ErrorKind::InvalidInput, res.unwrap_err().kind());
-    }
-
-    #[test]
-    fn test_statsd_client_distribution_duration_with_tags() {
-        let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client
-            .distribution_duration_with_tags("key", Duration::from_nanos(4096))
-            .with_tag("foo", "bar")
-            .with_tag_value("beta")
-            .try_send();
-
-        assert_eq!("prefix.key:4096|d|#foo:bar,beta", res.unwrap().as_metric_str());
-    }
-
-    #[test]
-    fn test_statsd_client_distribution_duration_with_tags_with_overflow() {
-        let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client
-            .distribution_duration_with_tags("key", Duration::from_millis(u64::MAX))
-            .with_tag("foo", "bar")
-            .with_tag_value("beta")
-            .try_send();
-
-        assert_eq!(ErrorKind::InvalidInput, res.unwrap_err().kind());
     }
 
     #[test]

--- a/cadence/src/lib.rs
+++ b/cadence/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Features
 //!
-//! * Support for emitting counters, timers, histograms, gauges, meters, and sets to
+//! * Support for emitting counters, timers, histograms, distributions, gauges, meters, and sets to
 //!   Statsd over UDP (or optionally Unix sockets).
 //! * Support for alternate backends via the `MetricSink` trait.
 //! * Support for [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) style metrics tags.
@@ -415,7 +415,7 @@ pub const DEFAULT_PORT: u16 = 8125;
 pub use self::builder::MetricBuilder;
 
 pub use self::client::{
-    Counted, Gauged, Histogrammed, Metered, MetricClient, Setted, StatsdClient, StatsdClientBuilder, Timed,
+    Counted, Distributed, Gauged, Histogrammed, Metered, MetricClient, Setted, StatsdClient, StatsdClientBuilder, Timed,
 };
 
 pub use self::sinks::{
@@ -423,7 +423,7 @@ pub use self::sinks::{
     UdpMetricSink,
 };
 
-pub use self::types::{Counter, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, MetricResult, Set, Timer};
+pub use self::types::{Counter, Distribution, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, MetricResult, Set, Timer};
 
 mod builder;
 mod client;

--- a/cadence/src/prelude.rs
+++ b/cadence/src/prelude.rs
@@ -26,4 +26,4 @@
 //! client.set("some.set", 123).unwrap();
 //! ```
 
-pub use crate::client::{Counted, Gauged, Histogrammed, Metered, MetricClient, Setted, Timed};
+pub use crate::client::{Counted, Distributed, Gauged, Histogrammed, Metered, MetricClient, Setted, Timed};

--- a/cadence/src/types.rs
+++ b/cadence/src/types.rs
@@ -162,6 +162,32 @@ impl Metric for Histogram {
     }
 }
 
+/// Distributions represent a global statistical distribution of a set of values.
+///
+/// See the `Distributed` trait for more information.
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub struct Distribution {
+    repr: String,
+}
+
+impl Distribution {
+    pub fn new(prefix: &str, key: &str, value: u64) -> Distribution {
+        MetricFormatter::distribution(prefix, key, value).build()
+    }
+}
+
+impl From<String> for Distribution {
+    fn from(s: String) -> Self {
+        Distribution { repr: s }
+    }
+}
+
+impl Metric for Distribution {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
 /// Sets count the number of unique elements in a group.
 ///
 /// See the `Setted` trait for more information.


### PR DESCRIPTION
This PR adds support for the Datadog-specific distribution metric type, documented [here](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition).