### PR TITLE
Rewrite spy metric sinks to use channels instead of shared writers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,22 @@
 
 ## master / unreleased
 
-* Added support for [DataDog distribution](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition)
+* **Breaking change** - Added support for
+  [DataDog distribution](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition)
   metric types per [#125](https://github.com/56quarters/cadence/pull/125)
   thanks to @duarten.
+* **Breaking change** - Rewrite `SpyMetricSink` and `BufferedSpyMetricSink`
+  introduced in 0.22.0 to use channels for making written metrics available
+  instead of shared `Write` implementation wrapped with a `Mutex`. The newly
+  changed sinks now return a `crossbeam_channel::Receiver<Vec<u8>>` instance
+  from their constructors that callers can use to read any metrics written by
+  the sink. This avoids accidental cases of [mutex poisoning](https://doc.rust-lang.org/nomicon/poisoning.html)
+  which can happen when the `Mutex` is held when an assertion fails as part of
+  a test per [#124](https://github.com/56quarters/cadence/issues/124).
+  
+  Examples of how to use the newly rewritten sinks can be found in:
+  * [cadence/examples/spy-sink.rs](cadence/examples/spy-sink.rs)
+  * [cadence-macros/tests/lib.rs](cadence-macros/tests/lib.rs)
 
 ## [v0.24.0](https://github.com/56quarters/cadence/tree/0.24.0) - 2021-02-02
 * Split the project into two crates. The `cadence` crate will continue to

--- a/cadence-macros/Cargo.toml
+++ b/cadence-macros/Cargo.toml
@@ -17,6 +17,7 @@ cadence = { path = "../cadence", version = "0.24" }
 
 [dev-dependencies]
 criterion = "0.3.1"
+crossbeam-channel = "0.5.0"
 
 [[bench]]
 name = "lib"

--- a/cadence-macros/tests/lib.rs
+++ b/cadence-macros/tests/lib.rs
@@ -2,56 +2,24 @@ use cadence::{SpyMetricSink, StatsdClient};
 use cadence_macros::{
     statsd_count, statsd_distribution, statsd_gauge, statsd_histogram, statsd_meter, statsd_set, statsd_time,
 };
-use std::io;
-use std::sync::{Arc, Mutex, Once};
+use crossbeam_channel::Receiver;
+use std::collections::HashSet;
+use std::sync::{Arc, Once};
 
-/// Underlying writer to be used by a `SpyMetricSink`
-static mut WRITER: Option<Arc<Mutex<TestWriter>>> = None;
+/// Channel to be used to inspect metrics written to a `SpyMetricSink`
+static mut RX: Option<Arc<Receiver<Vec<u8>>>> = None;
 
-/// Control initialization of the underlying writer
-static WRITER_INIT: Once = Once::new();
+/// Control initialization of the sink and channel being used
+static RX_INIT: Once = Once::new();
 
-/// `Write` implementation to use with a SpyMetricSink for testing
-///
-/// This write implementation converts all incoming writes to strings
-/// (assuming utf-8 encoding) and stores them in a vector that grows
-/// without bound.
-struct TestWriter {
-    saved: Vec<String>,
-}
-
-impl TestWriter {
-    fn new() -> Self {
-        TestWriter { saved: Vec::new() }
-    }
-
-    /// Get the underlying vector used for storage
-    fn storage(&self) -> &Vec<String> {
-        &self.saved
-    }
-}
-
-impl io::Write for TestWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // test code, this should never be invalid utf-8
-        let s = String::from_utf8(buf.to_vec()).unwrap();
-        self.saved.push(s);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Set a default client and save a reference to the underlying writer
+/// Set a default client and save a reference to channel for inspecting metrics
 fn init_default_client() {
-    WRITER_INIT.call_once(|| {
-        // Save a reference to the underlying writer used by the SpyMetricSink so
-        // that we can inspect its contents after every test. All metrics are saved
-        // so are able to assert that it contains the metric we just wrote.
+    RX_INIT.call_once(|| {
+        // Save a global reference to the receiver that the spy sink will make any
+        // written metrics available in.
+        let (rx, sink) = SpyMetricSink::new();
         unsafe {
-            WRITER = Some(Arc::new(Mutex::new(TestWriter::new())));
+            RX = Some(Arc::new(rx));
         }
 
         // Set the global default to be a client that writes to a SpyMetricSink so
@@ -59,94 +27,100 @@ fn init_default_client() {
         // safe to do this outside of the `call_once` block (since set_global_default
         // will only set the client a single time) but we might as well avoid extra
         // work if we can.
-        let sink = SpyMetricSink::from(unsafe { &WRITER }.clone().unwrap());
         cadence_macros::set_global_default(StatsdClient::from_sink("my.prefix", sink));
     });
 }
 
-/// Method to get the underlying vector of strings written to the sink.
-///
-/// This exists so that the lock for the writer is dropped before any assertions
-/// are made that might panic (and hence poison the lock).
-fn get_default_storage() -> Vec<String> {
-    let writer = unsafe { WRITER.clone() }.unwrap();
-    let inner = writer.lock().unwrap();
-    inner.storage().clone()
+/// Get the all strings written to the sink so far.
+fn read_all_metrics() -> HashSet<String> {
+    let rx = unsafe { RX.clone().unwrap() };
+
+    // We use a SpyMetricSink above (non-buffered) for the global client so each metric
+    // is a separate string that we can read from the channel and look for in our tests.
+    let mut out = HashSet::new();
+    while let Ok(v) = rx.try_recv() {
+        out.insert(String::from_utf8(v).unwrap());
+    }
+
+    out
 }
 
 #[test]
-fn test_statsd_count() {
+fn test_macros() {
+    // NOTE: We're testing all the macros as part of a single #[test] block
+    // because test functions are run in multiple threads by default and we
+    // wouldn't be able to guarantee which metrics were in the rx buffer when
+    // the test ran otherwise.
     init_default_client();
-    statsd_count!("some.counter", 123);
-    statsd_count!("some.counter", 123, "host" => "web01.example.com", "slice" => "a");
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.counter:123|c".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.counter:123|c|#host:web01.example.com,slice:a".to_owned()));
-}
+    fn test_counter_macros() {
+        statsd_count!("some.counter", 123);
+        statsd_count!("some.counter", 123, "host" => "web01.example.com", "slice" => "a");
 
-#[test]
-fn test_statsd_time() {
-    init_default_client();
-    statsd_time!("some.timer", 334);
-    statsd_time!("some.timer", 334, "type" => "api", "status" => "200");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.counter:123|c".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.counter:123|c|#host:web01.example.com,slice:a".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.timer:334|ms".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.timer:334|ms|#type:api,status:200".to_owned()));
-}
+    fn test_timer_macros() {
+        statsd_time!("some.timer", 334);
+        statsd_time!("some.timer", 334, "type" => "api", "status" => "200");
 
-#[test]
-fn test_statsd_gauge() {
-    init_default_client();
-    statsd_gauge!("some.gauge", 42);
-    statsd_gauge!("some.gauge", 42, "org" => "123", "service" => "gateway");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.timer:334|ms".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.timer:334|ms|#type:api,status:200".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.gauge:42|g".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.gauge:42|g|#org:123,service:gateway".to_owned()));
-}
+    fn test_gauge_macros() {
+        statsd_gauge!("some.gauge", 42);
+        statsd_gauge!("some.gauge", 42, "org" => "123", "service" => "gateway");
 
-#[test]
-fn test_statsd_meter() {
-    init_default_client();
-    statsd_meter!("some.meter", 1);
-    statsd_meter!("some.meter", 1, "foo" => "bar", "result" => "reject");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.gauge:42|g".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.gauge:42|g|#org:123,service:gateway".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.meter:1|m".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.meter:1|m|#foo:bar,result:reject".to_owned()));
-}
+    fn test_meter_macros() {
+        statsd_meter!("some.meter", 1);
+        statsd_meter!("some.meter", 1, "foo" => "bar", "result" => "reject");
 
-#[test]
-fn test_statsd_histogram() {
-    init_default_client();
-    statsd_histogram!("some.histogram", 223);
-    statsd_histogram!("some.histogram", 223, "method" => "auth", "result" => "error");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.meter:1|m".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.meter:1|m|#foo:bar,result:reject".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.histogram:223|h".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.histogram:223|h|#method:auth,result:error".to_owned()));
-}
+    fn test_histogram_macros() {
+        statsd_histogram!("some.histogram", 223);
+        statsd_histogram!("some.histogram", 223, "method" => "auth", "result" => "error");
 
-#[test]
-fn test_statsd_distribution() {
-    init_default_client();
-    statsd_distribution!("some.distribution", 223);
-    statsd_distribution!("some.distribution", 223, "method" => "auth", "result" => "error");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.histogram:223|h".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.histogram:223|h|#method:auth,result:error".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.distribution:223|d".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.distribution:223|d|#method:auth,result:error".to_owned()));
-}
+    fn test_distribution_macros() {
+        statsd_distribution!("some.distribution", 22);
+        statsd_distribution!("some.distribution", 22, "method" => "auth", "result" => "error");
 
-#[test]
-fn test_statsd_set() {
-    init_default_client();
-    statsd_set!("some.set", 348);
-    statsd_set!("some.set", 348, "service" => "user", "host" => "app01.example.com");
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.distribution:22|d".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.distribution:22|d|#method:auth,result:error".to_owned()));
+    }
 
-    let storage = get_default_storage();
-    assert!(storage.contains(&"my.prefix.some.set:348|s".to_owned()));
-    assert!(storage.contains(&"my.prefix.some.set:348|s|#service:user,host:app01.example.com".to_owned()));
+    fn test_set_macros() {
+        statsd_set!("some.set", 348);
+        statsd_set!("some.set", 348, "service" => "user", "host" => "app01.example.com");
+
+        let metrics = read_all_metrics();
+        assert!(metrics.contains(&"my.prefix.some.set:348|s".to_owned()));
+        assert!(metrics.contains(&"my.prefix.some.set:348|s|#service:user,host:app01.example.com".to_owned()));
+    }
+
+    test_counter_macros();
+    test_timer_macros();
+    test_gauge_macros();
+    test_meter_macros();
+    test_histogram_macros();
+    test_distribution_macros();
+    test_set_macros();
 }

--- a/cadence/tests/spy.rs
+++ b/cadence/tests/spy.rs
@@ -1,43 +1,41 @@
 use cadence::{BufferedSpyMetricSink, SpyMetricSink, StatsdClient};
-use std::sync::{Arc, Mutex};
 
 mod utils;
+use crossbeam_channel::Receiver;
 use utils::{run_arc_threaded_test, NUM_ITERATIONS, NUM_THREADS};
 
-fn new_spy_client(prefix: &str) -> StatsdClient {
-    let writer = Arc::new(Mutex::new(Vec::new()));
-    let sink = SpyMetricSink::from(writer);
-    StatsdClient::from_sink(prefix, sink)
+fn new_spy_client(prefix: &str) -> (Receiver<Vec<u8>>, StatsdClient) {
+    let (rx, sink) = SpyMetricSink::new();
+    (rx, StatsdClient::from_sink(prefix, sink))
 }
 
-fn new_buffered_spy_client(prefix: &str) -> StatsdClient {
-    let writer = Arc::new(Mutex::new(Vec::new()));
-    let sink = BufferedSpyMetricSink::from(writer);
-    StatsdClient::from_sink(prefix, sink)
+fn new_buffered_spy_client(prefix: &str) -> (Receiver<Vec<u8>>, StatsdClient) {
+    let (rx, sink) = BufferedSpyMetricSink::new();
+    (rx, StatsdClient::from_sink(prefix, sink))
 }
 
 #[test]
 fn test_statsd_client_spy_sink_single_threaded() {
-    let client = new_spy_client("cadence");
+    let (_rx, client) = new_spy_client("cadence");
     run_arc_threaded_test(client, 1, 1);
 }
 
 #[test]
 fn test_statsd_client_buffered_spy_sink_single_threaded() {
-    let client = new_buffered_spy_client("cadence");
+    let (_rx, client) = new_buffered_spy_client("cadence");
     run_arc_threaded_test(client, 1, 1);
 }
 
 #[ignore]
 #[test]
 fn test_statsd_client_spy_sink_many_threaded() {
-    let client = new_spy_client("cadence");
+    let (_rx, client) = new_spy_client("cadence");
     run_arc_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
 }
 
 #[ignore]
 #[test]
 fn test_statsd_client_buffered_spy_sink_many_threaded() {
-    let client = new_buffered_spy_client("cadence");
+    let (_rx, client) = new_buffered_spy_client("cadence");
     run_arc_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
 }


### PR DESCRIPTION
Rewrite `SpyMetricSink` and `BufferedSpyMetricSink` to use channels to
share metrics emitted with callers instead of a shared `Write` impl
protected by a `Mutex`. This avoids poisoning the mutex if a test
assertion fails while the mutex is held (which is common for something
meant to be used for testing).

Examples of how tests can be written against the new spy sinks can
be found in the cadence/examples/spy-sink.rs example as well as the
integration tests for cadence-macros.

Fixes #124

/cc @parasyte