### PR TITLE
Remove unsafe use of `static mut` causing undefined behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,12 @@
   Examples of how to use the newly rewritten sinks can be found in:
   * [cadence/examples/spy-sink.rs](cadence/examples/spy-sink.rs)
   * [cadence-macros/tests/lib.rs](cadence-macros/tests/lib.rs)
+* **Breaking change** - Remove unsafe uses of `static mut` used for global state
+  related to macros which caused undefined behavior per
+  [#129](https://github.com/56quarters/cadence/issues/129) thanks to @parasyte.
+  A consequence of  this that `cadence_macros::set_global_default` and
+  `cadence_macros::get_global_default` now only accept instances of `StatsdClient`,
+  not the trait `MetricClient`.
 
 ## [v0.24.0](https://github.com/56quarters/cadence/tree/0.24.0) - 2021-02-02
 * Split the project into two crates. The `cadence` crate will continue to

--- a/cadence-macros/src/lib.rs
+++ b/cadence-macros/src/lib.rs
@@ -98,7 +98,9 @@
 //!   `u64` can be used with the `statsd_gauge!` macro, not a `f64`.
 //!
 
-pub use crate::state::{get_global_default, is_global_default_set, set_global_default, GlobalDefaultNotSet};
+pub use crate::state::{
+    get_global_default, is_global_default_set, set_global_default, GlobalDefaultNotSet, SingletonHolder,
+};
 
 mod macros;
 mod state;

--- a/cadence-macros/src/macros.rs
+++ b/cadence-macros/src/macros.rs
@@ -365,6 +365,7 @@ macro_rules! statsd_set {
 #[doc(hidden)]
 macro_rules! _generate_impl {
     ($method:ident, $key:expr, $val:expr, $($tag_key:expr => $tag_val:expr),*) => {
+        use cadence::prelude::*;
         let client = $crate::get_global_default().unwrap();
         let builder = client.$method($key, $val);
         $(let builder = builder.with_tag($tag_key, $tag_val);)*


### PR DESCRIPTION
Uses of `static mut` have been replaced with a custom type that
controls access to mutable state via atomics.

Fixes #129