### PR TITLE
Fix docs now that multiple value types are supported

### DIFF
--- a/cadence-macros/README.md
+++ b/cadence-macros/README.md
@@ -100,9 +100,6 @@ Some limitations with the current implemenation of Cadence macros are described 
 
 * Value tags are not supported. For example the following style of tag cannot be
   set when using macros: `client.count_with_tags("some.counter", 123).with_tag_value("beta").send()`
-* Only a single type of value for each type of metric is supported. For example, only
-  `u64` can be used with the `statsd_time!` macro, not a `std::time::Duration`. Only
-  `u64` can be used with the `statsd_gauge!` macro, not a `f64`.
 
 ## Other
 

--- a/cadence-macros/src/lib.rs
+++ b/cadence-macros/src/lib.rs
@@ -99,9 +99,6 @@
 //!
 //! * Value tags are not supported. For example the following style of tag cannot be
 //!   set when using macros: `client.count_with_tags("some.counter", 123).with_tag_value("beta").send()`
-//! * Only a single type of value for each type of metric is supported. For example, only
-//!   `u64` can be used with the `statsd_time!` macro, not a `std::time::Duration`. Only
-//!   `u64` can be used with the `statsd_gauge!` macro, not a `f64`.
 //!
 
 pub use crate::state::{


### PR DESCRIPTION
Remove limitation that only a single type can be used for each metric
now that the vlaues passed are generic.