### PR TITLE
Implement drop for BufferedUdpMetricSink

### DIFF
--- a/cadence/src/sinks/udp.rs
+++ b/cadence/src/sinks/udp.rs
@@ -256,6 +256,12 @@ impl MetricSink for BufferedUdpMetricSink {
     }
 }
 
+impl Drop for BufferedUdpMetricSink {
+    fn drop(&mut self) {
+        self.flush().expect("metrcis were not flushed on drop")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{get_addr, BufferedUdpMetricSink, MetricSink, UdpMetricSink};


### PR DESCRIPTION
Implements `Drop` for `BufferedUdpMetricSink` so that the metrics are flushed, sometimes you have processes that run on scheduled basis and need `BufferedUdpMetricSink` but some metrics that are emitted at the end of such process may never get reported due to buffer not being flushed.

What do you think?