### PR TITLE
Create integration tests to verify heap allocations

### DIFF
--- a/cadence/tests/alloc-no-tags.rs
+++ b/cadence/tests/alloc-no-tags.rs
@@ -1,0 +1,25 @@
+use cadence::prelude::*;
+use cadence::{NopMetricSink, QueuingMetricSink, StatsdClient};
+use utils::InstrumentedAllocator;
+
+mod utils;
+
+#[global_allocator]
+static GLOBAL: InstrumentedAllocator = InstrumentedAllocator::new();
+
+#[test]
+fn test_allocs_statsdclient_nop_queuing_no_tags() {
+    let client = StatsdClient::from_sink("alloc.test", QueuingMetricSink::from(NopMetricSink));
+
+    // one initial metric while we're not recording to make sure any one-time costs don't
+    // count towards what we measure (seems like the channels used by the queuing sink do
+    // some lazy setup that results in about 1kb of allocation).
+    client.incr("foo").unwrap();
+
+    GLOBAL.enable();
+    client.incr("bar").unwrap();
+    GLOBAL.disable();
+
+    let num_allocs = GLOBAL.num_allocs();
+    assert_eq!(2, num_allocs)
+}

--- a/cadence/tests/alloc-with-tags.rs
+++ b/cadence/tests/alloc-with-tags.rs
@@ -1,0 +1,25 @@
+use cadence::prelude::*;
+use cadence::{NopMetricSink, QueuingMetricSink, StatsdClient};
+use utils::InstrumentedAllocator;
+
+mod utils;
+
+#[global_allocator]
+static GLOBAL: InstrumentedAllocator = InstrumentedAllocator::new();
+
+#[test]
+fn test_allocs_statsdclient_nop_queuing_with_tags() {
+    let client = StatsdClient::from_sink("alloc.test", QueuingMetricSink::from(NopMetricSink));
+
+    // one initial metric while we're not recording to make sure any one-time costs don't
+    // count towards what we measure (seems like the channels used by the queuing sink do
+    // some lazy setup that results in about 1kb of allocation).
+    client.incr("foo").unwrap();
+
+    GLOBAL.enable();
+    client.incr_with_tags("bar").with_tag("x", "y").send();
+    GLOBAL.disable();
+
+    let num_allocs = GLOBAL.num_allocs();
+    assert_eq!(3, num_allocs)
+}

--- a/cadence/tests/core.rs
+++ b/cadence/tests/core.rs
@@ -1,9 +1,9 @@
 use cadence::prelude::*;
 use cadence::{Counter, Gauge, Histogram, Meter, NopMetricSink, StatsdClient, Timer};
 use std::time::Duration;
+use utils::run_arc_threaded_test;
 
 mod utils;
-use utils::run_arc_threaded_test;
 
 fn new_nop_client(prefix: &str) -> StatsdClient {
     StatsdClient::from_sink(prefix, NopMetricSink)

--- a/cadence/tests/spy.rs
+++ b/cadence/tests/spy.rs
@@ -1,8 +1,8 @@
 use cadence::{BufferedSpyMetricSink, SpyMetricSink, StatsdClient};
-
-mod utils;
 use crossbeam_channel::Receiver;
 use utils::run_arc_threaded_test;
+
+mod utils;
 
 fn new_spy_client(prefix: &str) -> (Receiver<Vec<u8>>, StatsdClient) {
     let (rx, sink) = SpyMetricSink::new();

--- a/cadence/tests/udp.rs
+++ b/cadence/tests/udp.rs
@@ -1,8 +1,8 @@
 use cadence::{BufferedUdpMetricSink, QueuingMetricSink, StatsdClient, UdpMetricSink, DEFAULT_PORT};
 use std::net::UdpSocket;
+use utils::run_arc_threaded_test;
 
 mod utils;
-use utils::run_arc_threaded_test;
 
 const TARGET_HOST: (&str, u16) = ("127.0.0.1", DEFAULT_PORT);
 

--- a/cadence/tests/unix.rs
+++ b/cadence/tests/unix.rs
@@ -4,9 +4,9 @@ use cadence::test::UnixServerHarness;
 use cadence::{BufferedUnixMetricSink, QueuingMetricSink, StatsdClient, UnixMetricSink};
 use std::os::unix::net::UnixDatagram;
 use std::path::Path;
+use utils::run_arc_threaded_test;
 
 mod utils;
-use utils::run_arc_threaded_test;
 
 fn new_unix_client<P>(prefix: &str, path: P) -> StatsdClient
 where

--- a/cadence/tests/utils.rs
+++ b/cadence/tests/utils.rs
@@ -1,5 +1,9 @@
+#![allow(unused)]
+
 use cadence::prelude::*;
 use cadence::StatsdClient;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -35,5 +39,59 @@ pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations:
 
     for t in threads {
         t.join().unwrap();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct InstrumentedAllocator {
+    num_allocs: AtomicUsize,
+    num_bytes: AtomicUsize,
+    enabled: AtomicBool,
+}
+
+impl InstrumentedAllocator {
+    pub const fn new() -> Self {
+        InstrumentedAllocator {
+            num_allocs: AtomicUsize::new(0),
+            num_bytes: AtomicUsize::new(0),
+            enabled: AtomicBool::new(false),
+        }
+    }
+
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::Release);
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Acquire)
+    }
+
+    pub fn disable(&self) {
+        self.enabled.store(false, Ordering::Release);
+    }
+
+    pub fn num_allocs(&self) -> usize {
+        self.num_allocs.load(Ordering::Acquire)
+    }
+
+    pub fn num_bytes(&self) -> usize {
+        self.num_bytes.load(Ordering::Acquire)
+    }
+}
+
+unsafe impl GlobalAlloc for InstrumentedAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let res = System.alloc(layout);
+
+        if !res.is_null() && self.is_enabled() {
+            self.num_bytes.fetch_add(layout.size(), Ordering::Release);
+            self.num_allocs.fetch_add(1, Ordering::Release);
+        }
+
+        res
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
     }
 }


### PR DESCRIPTION
Create integration tests to verify how many heap allocations are done
when using the QueuingMetricSink, with and without tags. This ensures
that we don't accidentally drastically alter the behavior of the
library.

Fixes #158