### PR TITLE
Disable criterion benchmarks

### DIFF
--- a/cadence-macros/Cargo.toml
+++ b/cadence-macros/Cargo.toml
@@ -16,9 +16,4 @@ autobenches = false
 cadence = { path = "../cadence", version = "0.26" }
 
 [dev-dependencies]
-criterion = "=0.3.4"
 crossbeam-channel = "0.5.0"
-
-[[bench]]
-name = "lib"
-harness = false

--- a/cadence/Cargo.toml
+++ b/cadence/Cargo.toml
@@ -15,10 +15,4 @@ autobenches = false
 [dependencies]
 crossbeam-channel = "0.5.0"
 
-[dev-dependencies]
-criterion = "=0.3.4"
-
-[[bench]]
-name = "lib"
-harness = false
 


### PR DESCRIPTION
At the time it was added, Criterion was the only way to benchmark on
stable Rust. While useful, the number of dependencies it pulls it makes
it very difficult to support older versions of Rust.

Disable benchmarks until such time as our MSRV works with the various
dependencies Criterion pulls in.