### PR TITLE
Documentation and example updates related to packed values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## [v0.28.0](https://github.com/56quarters/cadence/tree/0.28.0) - Unreleased
-* Add support for [value packing](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11) in the Datadog Datagram which is available for Datadog agent
-versions `>=v6.25.0 && <v7.0.0` or `>=v7.25.0`. All metric types except set support this, since `:`
-could be in the value of a set. This allows clients to buffer histogram and distribution values
-and send them in fewer payloads to the agent. This feature was added by @Jason8Ni.
+* **Breaking change** - Add support for [packed values](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11)
+  which allows multiple values to be sent as a single metric for histogram,
+  distribution, and timer types. The Cadence client now accepts `Vec<T>` for
+  histogram, distribution, and timer methods. Note that this feature is a Datadog
+  extension and so may not be supported by your server. It is supported by versions
+  `>=v6.25.0 && <v7.0.0` or `>=v7.25.0` of the Datadog agent. Thanks to @Jason8Ni for
+  this contribution.
 
 ## [v0.27.0](https://github.com/56quarters/cadence/tree/0.27.0) - 2021-12-26
 * **Breaking change** - `StatsdClient` no longer implements the `Clone` trait

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,34 @@
 
 Guides for migrating to different versions of Cadence are below.
 
+## Migrating to 0.28
+
+In version `0.28` of Cadence, support was added for packed values.
+While this is a backwards incompatible change due to new variants of
+the `MetricValue` type and extensions to the types supported by the
+`MetricClient` trait, no changes are required for typical use of Cadence.
+
+If you find this is not the case, please open an issue.
+
+## Migrating to 0.27
+
+In version `0.27` of Cadence, the `StatsdClient` struct no longer
+implements the `Clone` trait. If you wish to clone instances of it
+you must now wrap it with a container that can be cloned.
+
+### Cloning using and `Arc`
+
+```rust
+use cadence::prelude::*;
+use cadence::{NopMetricSink, StatsdClient};
+
+fn main() {
+    let client = Arc::new(StatsdClient::from_sink("some.prefix", NopMetricSink));
+    let client_ref = client.clone();
+    client_ref.count("some.counter", 123).unwrap();
+}
+```
+
 ## Migrating To 0.26
 
 In version `0.26` of Cadence, the values for each type of metric are
@@ -38,15 +66,20 @@ of your metric values can be unambiguously determined.
 For example, give them explicit types
 
 ```rust
-let v: u64 = 42;
-client.time("some.key", v).unwrap();
+fn main() {
+    let v: u64 = 42;
+    client.time("some.key", v).unwrap();
+}
+
 ```
 
 Or cast them when passing to Cadence
 
 ```rust
-let v = 42;
-client.time("some.key", v as u64).unwrap();
+fn main() {
+    let v = 42;
+    client.time("some.key", v as u64).unwrap();
+}
 ```
 
 ### Moved methods

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -218,13 +218,20 @@ assert_eq!(
 
 ### Value Packing
 
-Value packing is supported for histograms, distributions, and timers when writing to the Datadog agent with the `UnixMetricSink` or `BufferedUnixMetricSink` sinks ... 
-versions `>=v6.25.0 && <v7.0.0` or `>=v7.25.0`. This feature allows clients to buffer values
-and send them in fewer payloads to the agent.
+Value packing allows multiple values to be sent as a single metric for histograms,
+distributions, and timer types. The Cadence client accepts `Vec<T>` for histogram,
+distribution, and timer methods and will format multiple values as described below.
+Note that this feature is a Datadog extension and so may not be supported by your
+server. It is supported by versions `>=v6.25.0 && <v7.0.0` or `>=v7.25.0` of the
+Datadog agent.
 
-For example, `<METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
+Packed metrics have the following format:
+```text
+<METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
+```
 
-See the [Datadog Docs](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11) for more information.
+See the [Datadog Docs](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11)
+for more information.
 
 ```rust
 use cadence::prelude::*;

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -42,9 +42,9 @@ impl ToCounterValue for i64 {
 /// Conversion trait for valid values for timers
 ///
 /// This trait must be implemented for any types that are used as timer
-/// values (currently `u64` and `Duration`). This trait is internal to how
-/// values are formatted as part of metrics but is exposed publicly for
-/// documentation purposes.
+/// values (currently `u64`, `Duration`, and `Vec`s of those types).
+/// This trait is internal to how values are formatted as part of metrics
+/// but is exposed publicly for documentation purposes.
 ///
 /// Typical use of Cadence shouldn't require interacting with this trait.
 pub trait ToTimerValue {
@@ -130,9 +130,9 @@ impl ToMeterValue for u64 {
 /// Conversion trait for valid values for histograms
 ///
 /// This trait must be implemented for any types that are used as histogram
-/// values (currently `u64`, `f64`, and `Duration`). This trait is internal
-/// to how values are formatted as part of metrics but is exposed publicly
-/// for documentation purposes.
+/// values (currently `u64`, `f64`, `Duration`, and `Vec`s of those types).
+/// This trait is internal to how values are formatted as part of metrics
+/// but is exposed publicly for documentation purposes.
 ///
 /// Typical use of Cadence shouldn't require interacting with this trait.
 pub trait ToHistogramValue {
@@ -189,9 +189,9 @@ impl ToHistogramValue for Vec<Duration> {
 /// Conversion trait for valid values for distributions
 ///
 /// This trait must be implemented for any types that are used as distribution
-/// values (currently `u64` and `f64`). This trait is internal to how values are
-/// formatted as part of metrics but is exposed publicly for documentation
-/// purposes.
+/// values (currently `u64`, `f64`, and `Vec`s of those types). This trait is
+/// internal to how values are formatted as part of metrics but is exposed
+/// publicly for documentation purposes.
 ///
 /// Typical use of Cadence shouldn't require interacting with this trait.
 pub trait ToDistributionValue {
@@ -491,11 +491,16 @@ where
 /// client.count("some.counter", 1).unwrap();
 /// client.time("some.timer", 42).unwrap();
 /// client.time("some.timer", Duration::from_millis(42)).unwrap();
+/// client.time("some.timer", vec![42]).unwrap();
+/// client.time("some.timer", vec![Duration::from_millis(42)]).unwrap();
 /// client.gauge("some.gauge", 8).unwrap();
 /// client.meter("some.meter", 13).unwrap();
 /// client.histogram("some.histogram", 4).unwrap();
 /// client.histogram("some.histogram", Duration::from_nanos(4)).unwrap();
+/// client.histogram("some.histogram", vec![4]).unwrap();
+/// client.histogram("some.histogram", vec![Duration::from_nanos(4)]).unwrap();
 /// client.distribution("some.distribution", 4).unwrap();
+/// client.distribution("some.distribution", vec![4]).unwrap();
 /// client.set("some.set", 5).unwrap();
 /// ```
 pub trait MetricClient:
@@ -503,14 +508,21 @@ pub trait MetricClient:
     + CountedExt
     + Timed<u64>
     + Timed<Duration>
+    + Timed<Vec<u64>>
+    + Timed<Vec<Duration>>
     + Gauged<u64>
     + Gauged<f64>
     + Metered<u64>
     + Histogrammed<u64>
     + Histogrammed<f64>
     + Histogrammed<Duration>
+    + Histogrammed<Vec<u64>>
+    + Histogrammed<Vec<f64>>
+    + Histogrammed<Vec<Duration>>
     + Distributed<u64>
     + Distributed<f64>
+    + Distributed<Vec<u64>>
+    + Distributed<Vec<f64>>
     + Setted<i64>
     + Compat
 {
@@ -1533,14 +1545,23 @@ mod tests {
         client.count("some.counter", 3).unwrap();
         client.time("some.timer", 198).unwrap();
         client.time("some.timer", Duration::from_millis(198)).unwrap();
+        client.time("some.timer", vec![198]).unwrap();
+        client.time("some.timer", vec![Duration::from_millis(198)]).unwrap();
         client.gauge("some.gauge", 4).unwrap();
         client.gauge("some.gauge", 4.0).unwrap();
         client.meter("some.meter", 29).unwrap();
         client.histogram("some.histogram", 32).unwrap();
         client.histogram("some.histogram", 32.0).unwrap();
         client.histogram("some.histogram", Duration::from_nanos(32)).unwrap();
+        client.histogram("some.histogram", vec![32]).unwrap();
+        client.histogram("some.histogram", vec![32.0]).unwrap();
+        client
+            .histogram("some.histogram", vec![Duration::from_nanos(32)])
+            .unwrap();
         client.distribution("some.distribution", 248).unwrap();
         client.distribution("some.distribution", 248.0).unwrap();
+        client.distribution("some.distribution", vec![248]).unwrap();
+        client.distribution("some.distribution", vec![248.0]).unwrap();
         client.set("some.set", 5).unwrap();
     }
 }

--- a/cadence/src/lib.rs
+++ b/cadence/src/lib.rs
@@ -216,12 +216,17 @@
 //!
 //! ### Value Packing
 //!
-//! Value packing is supported for `HISTOGRAM`, `DISTRIBUTION`, and `TIMING`
-//! metrics for Datadog agent versions `>=v6.25.0 && <v7.0.0` or `>=v7.25.0`.
-//! This feature allows clients to buffer values and send them in fewer payloads
-//! to the agent.
+//! Value packing allows multiple values to be sent as a single metric for histograms,
+//! distributions, and timer types. The Cadence client accepts `Vec<T>` for histogram,
+//! distribution, and timer methods and will format multiple values as described below.
+//! Note that this feature is a Datadog extension and so may not be supported by your
+//! server. It is supported by versions `>=v6.25.0 && <v7.0.0` or `>=v7.25.0` of the
+//! Datadog agent.
 //!
-//! For example, `<METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
+//! Packed metrics have the following format:
+//! ```text
+//! <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
+//! ```
 //!
 //! See the [Datadog Docs](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v11)
 //! for more information.


### PR DESCRIPTION
* Add examples with `Vec<T>` types to client methods
* Add new variants of `Timed`, etc traits to `MetricClient`
* Update migration guide for 0.27 and 0.28