### PR TITLE
Add cloneable wrapper MetricSink example.

### DIFF
--- a/cadence/examples/custom-value-type.rs
+++ b/cadence/examples/custom-value-type.rs
@@ -34,9 +34,9 @@ impl ToGaugeValue for UserHappiness {
 
 fn main() {
     let sink = NopMetricSink;
-    let metrics = StatsdClient::from_sink("example.prefix", sink);
+    let client = StatsdClient::from_sink("example.prefix", sink);
 
-    metrics.gauge("user.happiness", UserHappiness::VeryHappy).unwrap();
-    metrics.gauge("user.happiness", UserHappiness::KindaHappy).unwrap();
-    metrics.gauge("user.happiness", UserHappiness::Sad).unwrap();
+    client.gauge("user.happiness", UserHappiness::VeryHappy).unwrap();
+    client.gauge("user.happiness", UserHappiness::KindaHappy).unwrap();
+    client.gauge("user.happiness", UserHappiness::Sad).unwrap();
 }

--- a/cadence/examples/nop-sink.rs
+++ b/cadence/examples/nop-sink.rs
@@ -17,20 +17,18 @@ use std::time::Duration;
 
 fn main() {
     let sink = NopMetricSink;
-    let metrics = StatsdClient::from_sink("example.prefix", sink);
+    let client = StatsdClient::from_sink("example.prefix", sink);
 
-    metrics.count("example.counter", 1).unwrap();
-    metrics.gauge("example.gauge", 5).unwrap();
-    metrics.gauge("example.gauge", 5.0).unwrap();
-    metrics.time("example.timer", 32).unwrap();
-    metrics.time("example.timer", Duration::from_millis(32)).unwrap();
-    metrics.histogram("example.histogram", 22).unwrap();
-    metrics
-        .histogram("example.histogram", Duration::from_nanos(22))
-        .unwrap();
-    metrics.histogram("example.histogram", 22.0).unwrap();
-    metrics.distribution("example.distribution", 33).unwrap();
-    metrics.distribution("example.distribution", 33.0).unwrap();
-    metrics.meter("example.meter", 8).unwrap();
-    metrics.set("example.set", 44).unwrap();
+    client.count("example.counter", 1).unwrap();
+    client.gauge("example.gauge", 5).unwrap();
+    client.gauge("example.gauge", 5.0).unwrap();
+    client.time("example.timer", 32).unwrap();
+    client.time("example.timer", Duration::from_millis(32)).unwrap();
+    client.histogram("example.histogram", 22).unwrap();
+    client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+    client.histogram("example.histogram", 22.0).unwrap();
+    client.distribution("example.distribution", 33).unwrap();
+    client.distribution("example.distribution", 33.0).unwrap();
+    client.meter("example.meter", 8).unwrap();
+    client.set("example.set", 44).unwrap();
 }

--- a/cadence/examples/production-sink.rs
+++ b/cadence/examples/production-sink.rs
@@ -21,20 +21,18 @@ fn main() {
     let sock = UdpSocket::bind("0.0.0.0:0").unwrap();
     let buffered = BufferedUdpMetricSink::from(("localhost", DEFAULT_PORT), sock).unwrap();
     let queued = QueuingMetricSink::from(buffered);
-    let metrics = StatsdClient::from_sink("example.prefix", queued);
+    let client = StatsdClient::from_sink("example.prefix", queued);
 
-    metrics.count("example.counter", 1).unwrap();
-    metrics.gauge("example.gauge", 5).unwrap();
-    metrics.gauge("example.gauge", 5.0).unwrap();
-    metrics.time("example.timer", 32).unwrap();
-    metrics.time("example.timer", Duration::from_millis(32)).unwrap();
-    metrics.histogram("example.histogram", 22).unwrap();
-    metrics
-        .histogram("example.histogram", Duration::from_nanos(22))
-        .unwrap();
-    metrics.histogram("example.histogram", 22.0).unwrap();
-    metrics.distribution("example.distribution", 33).unwrap();
-    metrics.distribution("example.distribution", 33.0).unwrap();
-    metrics.meter("example.meter", 8).unwrap();
-    metrics.set("example.set", 44).unwrap();
+    client.count("example.counter", 1).unwrap();
+    client.gauge("example.gauge", 5).unwrap();
+    client.gauge("example.gauge", 5.0).unwrap();
+    client.time("example.timer", 32).unwrap();
+    client.time("example.timer", Duration::from_millis(32)).unwrap();
+    client.histogram("example.histogram", 22).unwrap();
+    client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+    client.histogram("example.histogram", 22.0).unwrap();
+    client.distribution("example.distribution", 33).unwrap();
+    client.distribution("example.distribution", 33.0).unwrap();
+    client.meter("example.meter", 8).unwrap();
+    client.set("example.set", 44).unwrap();
 }

--- a/cadence/examples/sending-tags.rs
+++ b/cadence/examples/sending-tags.rs
@@ -9,7 +9,9 @@
 
 // This example shows how you might use Cadence to send DataDog-style tags
 // either with a method the returns the result of sending them, or with a
-// method the delegates any errors to a predefined error handler.
+// method the delegates any errors to a predefined error handler. It also
+// includes "default" tags which are automatically added to any metrics
+// sent.
 
 use cadence::prelude::*;
 use cadence::{MetricError, NopMetricSink, StatsdClient};
@@ -19,8 +21,10 @@ fn main() {
         eprintln!("Error sending metrics: {}", err);
     }
 
+    // Create a client with an error handler and default "region" tag
     let client = StatsdClient::builder("my.prefix", NopMetricSink)
         .with_error_handler(my_error_handler)
+        .with_tag("region", "us-west-2")
         .build();
 
     // In this case we are sending a counter metric with two tag key-value
@@ -29,7 +33,7 @@ fn main() {
     client
         .count_with_tags("requests.handled", 1)
         .with_tag("app", "search")
-        .with_tag("region", "us-west-2")
+        .with_tag("user", "1234")
         .send();
 
     // In this case we are sending the same counter metrics with two tags.
@@ -38,7 +42,7 @@ fn main() {
     let res = client
         .count_with_tags("requests.handled", 1)
         .with_tag("app", "search")
-        .with_tag("region", "us-west-2")
+        .with_tag("user", "1234")
         .try_send();
 
     println!("Result of metric send: {:?}", res);

--- a/cadence/examples/simple-sink.rs
+++ b/cadence/examples/simple-sink.rs
@@ -19,20 +19,18 @@ use std::time::Duration;
 fn main() {
     let sock = UdpSocket::bind("0.0.0.0:0").unwrap();
     let sink = UdpMetricSink::from(("localhost", DEFAULT_PORT), sock).unwrap();
-    let metrics = StatsdClient::from_sink("example.prefix", sink);
+    let client = StatsdClient::from_sink("example.prefix", sink);
 
-    metrics.count("example.counter", 1).unwrap();
-    metrics.gauge("example.gauge", 5).unwrap();
-    metrics.gauge("example.gauge", 5.0).unwrap();
-    metrics.time("example.timer", 32).unwrap();
-    metrics.time("example.timer", Duration::from_millis(32)).unwrap();
-    metrics.histogram("example.histogram", 22).unwrap();
-    metrics
-        .histogram("example.histogram", Duration::from_nanos(22))
-        .unwrap();
-    metrics.histogram("example.histogram", 22.0).unwrap();
-    metrics.distribution("example.distribution", 33).unwrap();
-    metrics.distribution("example.distribution", 33.0).unwrap();
-    metrics.meter("example.meter", 8).unwrap();
-    metrics.set("example.set", 44).unwrap();
+    client.count("example.counter", 1).unwrap();
+    client.gauge("example.gauge", 5).unwrap();
+    client.gauge("example.gauge", 5.0).unwrap();
+    client.time("example.timer", 32).unwrap();
+    client.time("example.timer", Duration::from_millis(32)).unwrap();
+    client.histogram("example.histogram", 22).unwrap();
+    client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+    client.histogram("example.histogram", 22.0).unwrap();
+    client.distribution("example.distribution", 33).unwrap();
+    client.distribution("example.distribution", 33.0).unwrap();
+    client.meter("example.meter", 8).unwrap();
+    client.set("example.set", 44).unwrap();
 }

--- a/cadence/examples/spy-sink.rs
+++ b/cadence/examples/spy-sink.rs
@@ -22,22 +22,20 @@ fn main() {
         // Use a buffer size larger than any metrics here so we can demonstrate that
         // each metric ends up with a newline (\n) after it.
         let (rx, sink) = BufferedSpyMetricSink::with_capacity(None, Some(64));
-        let metrics = StatsdClient::from_sink("example.prefix", sink);
+        let client = StatsdClient::from_sink("example.prefix", sink);
 
-        metrics.count("example.counter", 1).unwrap();
-        metrics.gauge("example.gauge", 5).unwrap();
-        metrics.gauge("example.gauge", 5.0).unwrap();
-        metrics.time("example.timer", 32).unwrap();
-        metrics.time("example.timer", Duration::from_millis(32)).unwrap();
-        metrics.histogram("example.histogram", 22).unwrap();
-        metrics
-            .histogram("example.histogram", Duration::from_nanos(22))
-            .unwrap();
-        metrics.histogram("example.histogram", 22.0).unwrap();
-        metrics.distribution("example.distribution", 33).unwrap();
-        metrics.distribution("example.distribution", 33.0).unwrap();
-        metrics.meter("example.meter", 8).unwrap();
-        metrics.set("example.set", 44).unwrap();
+        client.count("example.counter", 1).unwrap();
+        client.gauge("example.gauge", 5).unwrap();
+        client.gauge("example.gauge", 5.0).unwrap();
+        client.time("example.timer", 32).unwrap();
+        client.time("example.timer", Duration::from_millis(32)).unwrap();
+        client.histogram("example.histogram", 22).unwrap();
+        client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+        client.histogram("example.histogram", 22.0).unwrap();
+        client.distribution("example.distribution", 33).unwrap();
+        client.distribution("example.distribution", 33.0).unwrap();
+        client.meter("example.meter", 8).unwrap();
+        client.set("example.set", 44).unwrap();
 
         rx
     };

--- a/cadence/examples/unix-socket.rs
+++ b/cadence/examples/unix-socket.rs
@@ -30,22 +30,20 @@ fn main() {
         |path| {
             let socket = UnixDatagram::unbound().unwrap();
             let sink = UnixMetricSink::from(path, socket);
-            let metrics = StatsdClient::from_sink("example.prefix", sink);
+            let client = StatsdClient::from_sink("example.prefix", sink);
 
-            metrics.count("example.counter", 1).unwrap();
-            metrics.gauge("example.gauge", 5).unwrap();
-            metrics.gauge("example.gauge", 5.0).unwrap();
-            metrics.time("example.timer", 32).unwrap();
-            metrics.time("example.timer", Duration::from_millis(32)).unwrap();
-            metrics.histogram("example.histogram", 22).unwrap();
-            metrics
-                .histogram("example.histogram", Duration::from_nanos(22))
-                .unwrap();
-            metrics.histogram("example.histogram", 22.0).unwrap();
-            metrics.distribution("example.distribution", 33).unwrap();
-            metrics.distribution("example.distribution", 33.0).unwrap();
-            metrics.meter("example.meter", 8).unwrap();
-            metrics.set("example.set", 44).unwrap();
+            client.count("example.counter", 1).unwrap();
+            client.gauge("example.gauge", 5).unwrap();
+            client.gauge("example.gauge", 5.0).unwrap();
+            client.time("example.timer", 32).unwrap();
+            client.time("example.timer", Duration::from_millis(32)).unwrap();
+            client.histogram("example.histogram", 22).unwrap();
+            client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+            client.histogram("example.histogram", 22.0).unwrap();
+            client.distribution("example.distribution", 33).unwrap();
+            client.distribution("example.distribution", 33.0).unwrap();
+            client.meter("example.meter", 8).unwrap();
+            client.set("example.set", 44).unwrap();
         },
     );
 }

--- a/cadence/examples/wrapped.rs
+++ b/cadence/examples/wrapped.rs
@@ -1,0 +1,72 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// To the extent possible under law, the author(s) have dedicated all copyright and
+// related and neighboring rights to this file to the public domain worldwide.
+// This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication along with this
+// software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+use std::io;
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cadence::prelude::*;
+use cadence::{MetricSink, NopMetricSink, StatsdClient};
+
+// This example shows how you might use a `MetricSink` with Cadence while
+// retaining a reference to it in order to periodically call it's `flush`
+// method.
+
+/// MetricSink implementation that delegates to another referenced counted
+/// implementation.
+#[derive(Clone)]
+pub struct CloneableSink {
+    wrapped: Arc<dyn MetricSink + Send + Sync + RefUnwindSafe + 'static>,
+}
+
+impl CloneableSink {
+    pub fn new<T>(wrapped: T) -> Self
+    where
+        T: MetricSink + Send + Sync + RefUnwindSafe + 'static,
+    {
+        Self {
+            wrapped: Arc::new(wrapped),
+        }
+    }
+}
+
+impl MetricSink for CloneableSink {
+    fn emit(&self, metric: &str) -> io::Result<usize> {
+        self.wrapped.emit(metric)
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.wrapped.flush()
+    }
+}
+
+fn main() {
+    let real_sink = NopMetricSink;
+    let reference1 = CloneableSink::new(real_sink);
+    let reference2 = reference1.clone();
+    let client = StatsdClient::from_sink("prefix", reference1);
+
+    let _ = reference2.flush();
+
+    client.count("example.counter", 1).unwrap();
+    client.gauge("example.gauge", 5).unwrap();
+    client.gauge("example.gauge", 5.0).unwrap();
+    client.time("example.timer", 32).unwrap();
+    client.time("example.timer", Duration::from_millis(32)).unwrap();
+    client.histogram("example.histogram", 22).unwrap();
+    client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+    client.histogram("example.histogram", 22.0).unwrap();
+    client.distribution("example.distribution", 33).unwrap();
+    client.distribution("example.distribution", 33.0).unwrap();
+    client.meter("example.meter", 8).unwrap();
+    client.set("example.set", 44).unwrap();
+
+    let _ = reference2.flush();
+}


### PR DESCRIPTION
Add example of how to retain a reference to a wrapped sink such
that its flush method can be periodically called. This exists to
document how users to Cadence could call any lifecycle methods on
a wrapped sink required.