### PR TITLE
`StatsdClient` flush functionality

### DIFF
--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -939,10 +939,7 @@ impl StatsdClient {
     /// client.flush();
     /// ```
     pub fn flush(&self) -> MetricResult<()> {
-        match self.sink.flush() {
-            Ok(_) => Ok(()),
-            Err(error) => Err(MetricError::from(error)),
-        }
+        Ok(self.sink.flush()?)
     }
 
     // Create a new StatsdClient by consuming the builder

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -941,7 +941,7 @@ impl StatsdClient {
     pub fn flush(&self) -> MetricResult<()> {
         match self.sink.flush() {
             Ok(_) => Ok(()),
-            Err(_) => Err(MetricError::from((ErrorKind::IoError, "flush error")))
+            Err(_) => Err(MetricError::from((ErrorKind::IoError, "flush error"))),
         }
     }
 

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -23,7 +23,7 @@ use std::u64;
 /// Conversion trait for valid values for counters
 ///
 /// This trait must be implemented for any types that are used as counter
-/// values (currently only `i64`, `i32`, `u64`, and `u32`). This trait is internal to how values are
+/// values (currently only `i64`). This trait is internal to how values are
 /// formatted as part of metrics but is exposed publicly for documentation
 /// purposes.
 ///
@@ -35,24 +35,6 @@ pub trait ToCounterValue {
 impl ToCounterValue for i64 {
     fn try_to_value(self) -> MetricResult<MetricValue> {
         Ok(MetricValue::Signed(self))
-    }
-}
-
-impl ToCounterValue for i32 {
-    fn try_to_value(self) -> MetricResult<MetricValue> {
-        Ok(MetricValue::Signed(self.into()))
-    }
-}
-
-impl ToCounterValue for u64 {
-    fn try_to_value(self) -> MetricResult<MetricValue> {
-        Ok(MetricValue::Unsigned(self))
-    }
-}
-
-impl ToCounterValue for u32 {
-    fn try_to_value(self) -> MetricResult<MetricValue> {
-        Ok(MetricValue::Unsigned(self.into()))
     }
 }
 

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -23,7 +23,7 @@ use std::u64;
 /// Conversion trait for valid values for counters
 ///
 /// This trait must be implemented for any types that are used as counter
-/// values (currently only `i64`). This trait is internal to how values are
+/// values (currently only `i64`, `i32`, `u64`, and `u32`). This trait is internal to how values are
 /// formatted as part of metrics but is exposed publicly for documentation
 /// purposes.
 ///
@@ -38,9 +38,21 @@ impl ToCounterValue for i64 {
     }
 }
 
+impl ToCounterValue for i32 {
+    fn try_to_value(self) -> MetricResult<MetricValue> {
+        Ok(MetricValue::Signed(self.into()))
+    }
+}
+
 impl ToCounterValue for u64 {
     fn try_to_value(self) -> MetricResult<MetricValue> {
         Ok(MetricValue::Unsigned(self))
+    }
+}
+
+impl ToCounterValue for u32 {
+    fn try_to_value(self) -> MetricResult<MetricValue> {
+        Ok(MetricValue::Unsigned(self.into()))
     }
 }
 

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -953,7 +953,7 @@ impl StatsdClient {
     /// client.count("time-sensitive.keyA", 1);
     /// client.count("time-sensitive.keyB", 2);
     /// client.count("time-sensitive.keyC", 3);
-    /// ...
+    /// // Any number of time-sensitive metrics ... //
     /// client.flush();
     /// ```
     pub fn flush(&self) -> io::Result<()> {

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -15,6 +15,7 @@ use crate::types::{
     Counter, Distribution, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, MetricResult, Set, Timer,
 };
 use std::fmt;
+use std::io;
 use std::panic::RefUnwindSafe;
 use std::time::Duration;
 use std::u64;
@@ -34,6 +35,12 @@ pub trait ToCounterValue {
 impl ToCounterValue for i64 {
     fn try_to_value(self) -> MetricResult<MetricValue> {
         Ok(MetricValue::Signed(self))
+    }
+}
+
+impl ToCounterValue for u64 {
+    fn try_to_value(self) -> MetricResult<MetricValue> {
+        Ok(MetricValue::Unsigned(self))
     }
 }
 
@@ -920,6 +927,10 @@ impl StatsdClient {
 
     fn tags(&self) -> impl IntoIterator<Item = (Option<&str>, &str)> {
         self.tags.iter().map(|(k, v)| (k.as_deref(), v.as_str()))
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.sink.flush()
     }
 }
 

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -940,6 +940,7 @@ impl StatsdClient {
     ///
     /// ```
     /// use std::net::UdpSocket;
+    /// use cadence::prelude::*;
     /// use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
     ///
     /// let prefix = "my.stats";

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -940,7 +940,7 @@ impl StatsdClient {
     /// client.flush();
     /// ```
     pub fn flush(&self) -> io::Result<()> {
-        self.sink.flush()
+        Ok(self.sink.flush()?)
     }
 
     // Create a new StatsdClient by consuming the builder

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -15,7 +15,6 @@ use crate::types::{
     Counter, Distribution, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, MetricResult, Set, Timer,
 };
 use std::fmt;
-use std::io;
 use std::panic::RefUnwindSafe;
 use std::time::Duration;
 use std::u64;
@@ -939,8 +938,11 @@ impl StatsdClient {
     /// // Any number of time-sensitive metrics ... //
     /// client.flush();
     /// ```
-    pub fn flush(&self) -> io::Result<()> {
-        Ok(self.sink.flush()?)
+    pub fn flush(&self) -> MetricResult<()> {
+        match self.sink.flush() {
+            Ok(_) => Ok(()),
+            Err(_) => Err(MetricError::from((ErrorKind::IoError, "flush error")))
+        }
     }
 
     // Create a new StatsdClient by consuming the builder

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -941,7 +941,7 @@ impl StatsdClient {
     pub fn flush(&self) -> MetricResult<()> {
         match self.sink.flush() {
             Ok(_) => Ok(()),
-            Err(_) => Err(MetricError::from((ErrorKind::IoError, "flush error"))),
+            Err(error) => Err(MetricError::from(error)),
         }
     }
 


### PR DESCRIPTION
# Problem
The `StatsDClient` utilizes a `MetricSink`, which can optionally be buffered. Buffering helps save network bandwidth; however, the `BufferedUdpMetricSink` won't be flushed until it is full. For, an application which emits relatively few time-sensitive metrics in conjunction with a large amount of time-insensitive metrics, the default buffer flushing may not give the user enough control and result in faulty metric collection (especially since StatsD does not tag metics with a timestamp).

# Solution
I have added a `pub fn flush()` to the `StatsDClient` which gives users the control they need to flush time-sensitive metrics while also allowing the regular buffer functionality to flush once the buffer is full. Also, I added a `ToCounterValue` implementation for the u64 type since most counters are unsigned.