### PR TITLE
Documentation updates and version bump for 1.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.4.0](https://github.com/56quarters/cadence/tree/1.4.0) - 2024-04-28
+* Make the previously internal `MultiLineWriter` and `SocketStats` structs
+  available from the `cadence::ext` module per [#206](https://github.com/56quarters/cadence/pull/206). 
+  These can be useful when creating custom `MetricSink` implementations.
+  Thanks to @mlowicki for this contribution.
+
 ## [v1.3.0](https://github.com/56quarters/cadence/tree/1.3.0) - 2024-03-23
 * Add support for using `u64`, `i32`, and `u32` types as counters per
   [#201](https://github.com/56quarters/cadence/pull/201). Thanks to @James-Bartman

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,14 @@
 
 Guides for migrating to different versions of Cadence are below.
 
+## Migrating to 1.4.0
+
+There are no backwards incompatible changes in this release.
+
+## Migrating to 1.3.0
+
+There are no backwards incompatible changes in this release.
+
 ## Migrating to 1.2.0
 
 There are no backwards incompatible changes in this release.

--- a/cadence-macros/Cargo.toml
+++ b/cadence-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadence-macros"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Nick Pillitteri"]
 description = "Macros for Cadence, an extensible Statsd client for Rust"
 homepage = "https://github.com/56quarters/cadence"
@@ -13,7 +13,7 @@ edition = "2021"
 autobenches = false
 
 [dependencies]
-cadence = { path = "../cadence", version = "1.3" }
+cadence = { path = "../cadence", version = "1.4" }
 
 [dev-dependencies]
 crossbeam-channel = "0.5.1"

--- a/cadence/Cargo.toml
+++ b/cadence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadence"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Nick Pillitteri"]
 description = "An extensible Statsd client for Rust"
 homepage = "https://github.com/56quarters/cadence"


### PR DESCRIPTION
Bumps version, updates the changelog, migration guide, and add type docs for newly exported types.