### PR TITLE
Use appropriate atomic ordering for macro state

### DIFF
--- a/cadence-macros/src/state.rs
+++ b/cadence-macros/src/state.rs
@@ -29,7 +29,7 @@ static HOLDER: SingletonHolder<StatsdClient> = SingletonHolder::new();
 /// this crate but it is not part of the public API and may change at any
 /// time.
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SingletonHolder<T> {
     value: UnsafeCell<Option<Arc<T>>>,
     state: AtomicUsize,
@@ -65,7 +65,7 @@ impl<T> SingletonHolder<T> {
     pub fn set(&self, val: T) {
         if self
             .state
-            .compare_exchange(UNSET, LOADING, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(UNSET, LOADING, Ordering::AcqRel, Ordering::Relaxed)
             .is_err()
         {
             return;

--- a/cadence-macros/tests/lib.rs
+++ b/cadence-macros/tests/lib.rs
@@ -46,8 +46,8 @@ fn test_macros() {
         statsd_count!("some.counter", 123, "host" => "web01.example.com", "slice" => "a");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.counter:123|c".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.counter:123|c|#host:web01.example.com,slice:a".to_owned()));
+        assert!(metrics.contains("my.prefix.some.counter:123|c"));
+        assert!(metrics.contains("my.prefix.some.counter:123|c|#host:web01.example.com,slice:a"));
     }
 
     fn test_timer_macros() {
@@ -56,9 +56,9 @@ fn test_macros() {
         statsd_time!("some.timer", Duration::from_millis(334), "type" => "web");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.timer:334|ms".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.timer:334|ms|#type:api,status:200".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.timer:334|ms|#type:web".to_owned()));
+        assert!(metrics.contains("my.prefix.some.timer:334|ms"));
+        assert!(metrics.contains("my.prefix.some.timer:334|ms|#type:api,status:200"));
+        assert!(metrics.contains("my.prefix.some.timer:334|ms|#type:web"));
     }
 
     fn test_gauge_macros() {
@@ -67,9 +67,9 @@ fn test_macros() {
         statsd_gauge!("some.gauge", 35.4, "org" => "456");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.gauge:42|g".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.gauge:42|g|#org:123,service:gateway".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.gauge:35.4|g|#org:456".to_owned()));
+        assert!(metrics.contains("my.prefix.some.gauge:42|g"));
+        assert!(metrics.contains("my.prefix.some.gauge:42|g|#org:123,service:gateway"));
+        assert!(metrics.contains("my.prefix.some.gauge:35.4|g|#org:456"));
     }
 
     fn test_meter_macros() {
@@ -77,8 +77,8 @@ fn test_macros() {
         statsd_meter!("some.meter", 1, "foo" => "bar", "result" => "reject");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.meter:1|m".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.meter:1|m|#foo:bar,result:reject".to_owned()));
+        assert!(metrics.contains("my.prefix.some.meter:1|m"));
+        assert!(metrics.contains("my.prefix.some.meter:1|m|#foo:bar,result:reject"));
     }
 
     fn test_histogram_macros() {
@@ -88,10 +88,10 @@ fn test_macros() {
         statsd_histogram!("some.histogram", 22.3, "method" => "list");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.histogram:223|h".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.histogram:223|h|#method:auth,result:error".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.histogram:223|h|#method:list".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.histogram:22.3|h|#method:list".to_owned()));
+        assert!(metrics.contains("my.prefix.some.histogram:223|h"));
+        assert!(metrics.contains("my.prefix.some.histogram:223|h|#method:auth,result:error"));
+        assert!(metrics.contains("my.prefix.some.histogram:223|h|#method:list"));
+        assert!(metrics.contains("my.prefix.some.histogram:22.3|h|#method:list"));
     }
 
     fn test_distribution_macros() {
@@ -100,9 +100,9 @@ fn test_macros() {
         statsd_distribution!("some.distribution", 2.21, "method" => "list");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.distribution:22|d".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.distribution:22|d|#method:auth,result:error".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.distribution:2.21|d|#method:list".to_owned()));
+        assert!(metrics.contains("my.prefix.some.distribution:22|d"));
+        assert!(metrics.contains("my.prefix.some.distribution:22|d|#method:auth,result:error"));
+        assert!(metrics.contains("my.prefix.some.distribution:2.21|d|#method:list"));
     }
 
     fn test_set_macros() {
@@ -110,8 +110,8 @@ fn test_macros() {
         statsd_set!("some.set", 348, "service" => "user", "host" => "app01.example.com");
 
         let metrics = read_all_metrics();
-        assert!(metrics.contains(&"my.prefix.some.set:348|s".to_owned()));
-        assert!(metrics.contains(&"my.prefix.some.set:348|s|#service:user,host:app01.example.com".to_owned()));
+        assert!(metrics.contains("my.prefix.some.set:348|s"));
+        assert!(metrics.contains("my.prefix.some.set:348|s|#service:user,host:app01.example.com"));
     }
 
     test_counter_macros();


### PR DESCRIPTION
Switch ordering used for `compare_exchange` when setting global macro state.
Use `AcqRel` for success to create an ordering relationship with reads from
the method `is_set` or other calls of `set`. Use and `Relaxed` for failure
because we don't care about the value when the compare-and-set fails.

Related #208