### PR TITLE
Support all Datadog statsd extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cadence is a fast and flexible way to emit Statsd metrics from your application.
 * [Support](https://docs.rs/cadence/) for emitting counters, timers, histograms, distributions,
   gauges, meters, and sets to Statsd over UDP (or optionally Unix sockets).
 * Support for alternate backends via the `MetricSink` trait.
-* Support for [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) style metrics tags.
+* Support for [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) style metrics tags and extensions.
 * [Macros](https://docs.rs/cadence-macros/) to simplify common calls to emit metrics
 * A simple yet flexible API for sending metrics.
 

--- a/cadence/examples/datadog-extensions.rs
+++ b/cadence/examples/datadog-extensions.rs
@@ -1,0 +1,44 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// To the extent possible under law, the author(s) have dedicated all copyright and
+// related and neighboring rights to this file to the public domain worldwide.
+// This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication along with this
+// software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+// This example shows how you set a timestamp, sampling rate or container id
+// as described on https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/.
+
+use cadence::prelude::*;
+use cadence::{MetricError, NopMetricSink, StatsdClient};
+
+fn main() {
+    fn my_error_handler(err: MetricError) {
+        eprintln!("Error sending metrics: {}", err);
+    }
+
+    // Create a client with an error handler and default "region" tag
+    let client = StatsdClient::builder("my.prefix", NopMetricSink)
+        .with_error_handler(my_error_handler)
+        .with_container_id("container-123")
+        .build();
+
+    // In this case we are sending a counter metric with manually set timestamp,
+    // container id and sampling rate. If sending the metric fails, our error
+    // handler set above will be invoked to do something with the metric error.
+    client
+        .count_with_tags("counter.1", 1)
+        .with_timestamp(123456)
+        .with_container_id("container-456")
+        .with_sampling_rate(0.5)
+        .send();
+
+    // In this case we are sending the same counter metrics without any explicit container
+    // id, meaning that the client's container id will be used.
+    let res = client
+        .count_with_tags("counter.2", 1)
+        .try_send();
+
+    println!("Result of metric send: {:?}", res);
+}

--- a/cadence/examples/datadog-extensions.rs
+++ b/cadence/examples/datadog-extensions.rs
@@ -36,9 +36,7 @@ fn main() {
 
     // In this case we are sending the same counter metrics without any explicit container
     // id, meaning that the client's container id will be used.
-    let res = client
-        .count_with_tags("counter.2", 1)
-        .try_send();
+    let res = client.count_with_tags("counter.2", 1).try_send();
 
     println!("Result of metric send: {:?}", res);
 }

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -478,7 +478,7 @@ where
         self
     }
 
-    /// Add a timestamp to this metric.
+    /// Add a UNIX timestamp in seconds to this metric.
     /// # Example
     ///
     /// ```

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -238,7 +238,8 @@ impl<'a> MetricFormatter<'a> {
 
     fn timestamp_size_hint(&self) -> usize {
         if let Some(_timestamp) = self.timestamp {
-            /* |T */ 2 + /* timestamp */ 10
+            /* |T */
+            2 + /* timestamp */ 10
         } else {
             0
         }
@@ -246,7 +247,8 @@ impl<'a> MetricFormatter<'a> {
 
     fn sampling_rate_size_hint(&self) -> usize {
         if let Some(_rate) = self.sampling_rate {
-            /* |@ */ 2 + /* rate */ 10
+            /* |@ */
+            2 + /* rate */ 10
         } else {
             0
         }
@@ -254,14 +256,19 @@ impl<'a> MetricFormatter<'a> {
 
     fn container_id_size_hint(&self) -> usize {
         if let Some(container_id) = self.container_id {
-            /* |c */ 2 + container_id.len()
+            /* |c */
+            2 + container_id.len()
         } else {
             0
         }
     }
 
     fn size_hint(&self) -> usize {
-        self.base_size + self.sampling_rate_size_hint() + self.tag_size_hint() + self.timestamp_size_hint() + self.container_id_size_hint()
+        self.base_size
+            + self.sampling_rate_size_hint()
+            + self.tag_size_hint()
+            + self.timestamp_size_hint()
+            + self.container_id_size_hint()
     }
 
     pub(crate) fn format(&self) -> String {
@@ -462,7 +469,7 @@ where
         self
     }
 
-    pub (crate) fn with_container_id_opt(mut self, container_id: Option<&'m str>) -> Self {
+    pub(crate) fn with_container_id_opt(mut self, container_id: Option<&'m str>) -> Self {
         if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
             if let Some(container_id) = container_id {
                 formatter.with_container_id(container_id);
@@ -788,7 +795,8 @@ mod tests {
 
     #[test]
     fn test_metric_formatter_sampling_rate() {
-        let mut fmt = MetricFormatter::distribution("prefix.", "some.key", MetricValue::PackedUnsigned(vec![44, 45, 46]));
+        let mut fmt =
+            MetricFormatter::distribution("prefix.", "some.key", MetricValue::PackedUnsigned(vec![44, 45, 46]));
         fmt.with_sampling_rate(0.5);
 
         let expected = "prefix.some.key:44:45:46|d|@0.5";
@@ -798,7 +806,8 @@ mod tests {
 
     #[test]
     fn test_metric_formatter_sampling_rate_small() {
-        let mut fmt = MetricFormatter::distribution("prefix.", "some.key", MetricValue::PackedUnsigned(vec![44, 45, 46]));
+        let mut fmt =
+            MetricFormatter::distribution("prefix.", "some.key", MetricValue::PackedUnsigned(vec![44, 45, 46]));
         fmt.with_sampling_rate(0.000000000000000000001);
 
         let expected = "prefix.some.key:44:45:46|d|@0.000000000000000000001";

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -493,7 +493,7 @@ where
     ///   .try_send();
     ///
     /// assert_eq!(
-    ///   "some.prefix.some.key:1|c|t:timestamp",
+    ///   "some.prefix.some.key:1|c|T".to_string() + &timestamp.to_string(),
     ///  res.unwrap().as_metric_str()
     /// );
     /// ```
@@ -511,13 +511,13 @@ where
     /// use cadence::prelude::*;
     /// use cadence::{StatsdClient, NopMetricSink, Metric};
     ///
-    /// let client = StatsdClient::from_sink("some.prefix", NopMetricSink)
+    /// let client = StatsdClient::from_sink("some.prefix", NopMetricSink);
     /// let res = client.distribution_with_tags("some.key", 1)
     ///  .with_sampling_rate(0.5)
     ///  .try_send();
     ///
     /// assert_eq!(
-    ///  "some.prefix.some.key:1|c|@0.50000000",
+    ///  "some.prefix.some.key:1|d|@0.5",
     ///  res.unwrap().as_metric_str()
     /// );
     pub fn with_sampling_rate(mut self, rate: f64) -> Self {

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -801,7 +801,7 @@ mod tests {
 
         let expected = "prefix.some.key:44:45:46|d|@0.5";
         assert_eq!(expected, &fmt.format());
-        assert_eq!(41, fmt.size_hint());
+        assert_eq!(61, fmt.size_hint());
     }
 
     #[test]
@@ -812,7 +812,7 @@ mod tests {
 
         let expected = "prefix.some.key:44:45:46|d|@0.000000000000000000001";
         assert_eq!(expected, &fmt.format());
-        assert_eq!(41, fmt.size_hint());
+        assert_eq!(61, fmt.size_hint());
     }
 
     #[test]

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -807,7 +807,7 @@ mod tests {
 
         let expected = "prefix.some.key:44:45:46|d|@0.5";
         assert_eq!(expected, &fmt.format());
-        assert_eq!(61, fmt.size_hint());
+        assert_eq!(68, fmt.size_hint());
     }
 
     #[test]
@@ -818,7 +818,7 @@ mod tests {
 
         let expected = "prefix.some.key:44:45:46|d|@0.000000000000000000001";
         assert_eq!(expected, &fmt.format());
-        assert_eq!(61, fmt.size_hint());
+        assert_eq!(68, fmt.size_hint());
     }
 
     #[test]

--- a/cadence/src/builder.rs
+++ b/cadence/src/builder.rs
@@ -248,7 +248,7 @@ impl<'a> MetricFormatter<'a> {
     fn sampling_rate_size_hint(&self) -> usize {
         if let Some(_rate) = self.sampling_rate {
             /* |@ */
-            2 + /* rate */ 10
+            2 + /* rate */ 17 /* MAX_SIG_DIGITS */
         } else {
             0
         }
@@ -506,6 +506,12 @@ where
     }
 
     /// Add a sampling rate to this metric.
+    ///
+    /// The sampling rate is a float between 0 and 1 that determines the rate at which
+    /// the metric is sampled. For example, a sampling rate of 0.5 would mean that the
+    /// metric is sent 50% of the time. The sampling has to be done by the caller, cadence
+    /// will simply forward it to the backend.
+    ///
     /// # Example
     /// ```
     /// use cadence::prelude::*;

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -736,7 +736,10 @@ impl StatsdClientBuilder {
 
     /// Add a default container ID to every metric published by the built
     /// [StatsdClient].
-    pub fn with_container_id(mut self, container_id: &str) -> Self {
+    pub fn with_container_id<K>(mut self, container_id: K) -> Self
+    where
+        K: ToString,
+    {
         self.container_id = Some(container_id.to_string());
         self
     }

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -676,7 +676,7 @@ pub struct StatsdClientBuilder {
     sink: Box<dyn MetricSink + Sync + Send + RefUnwindSafe>,
     errors: Box<dyn Fn(MetricError) + Sync + Send + RefUnwindSafe>,
     tags: Vec<(Option<String>, String)>,
-    container_id: Option<String>
+    container_id: Option<String>,
 }
 
 impl StatsdClientBuilder {
@@ -1026,11 +1026,9 @@ where
 {
     fn count_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Counter> {
         match value.try_to_value() {
-            Ok(v) => {
-                MetricBuilder::from_fmt(MetricFormatter::counter(&self.prefix, key, v), self)
-                    .with_tags(self.tags())
-                    .with_container_id_opt(self.container_id.as_deref())
-            }
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::counter(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1086,11 +1084,9 @@ where
 {
     fn histogram_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Histogram> {
         match value.try_to_value() {
-            Ok(v) => {
-                MetricBuilder::from_fmt(MetricFormatter::histogram(&self.prefix, key, v), self)
-                    .with_tags(self.tags())
-                    .with_container_id_opt(self.container_id.as_deref())
-            }
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::histogram(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1268,7 +1264,10 @@ mod tests {
     #[test]
     fn test_statsd_client_gauge_with_timestamp() {
         let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client.gauge_with_tags("some.gauge", 4).with_timestamp(1234567890).try_send();
+        let res = client
+            .gauge_with_tags("some.gauge", 4)
+            .with_timestamp(1234567890)
+            .try_send();
 
         assert_eq!("prefix.some.gauge:4|g|T1234567890", res.unwrap().as_metric_str());
     }
@@ -1567,11 +1566,13 @@ mod tests {
     #[test]
     fn test_statsd_client_distribution_with_sampling_rate() {
         let client = StatsdClient::from_sink("prefix", NopMetricSink);
-        let res = client.distribution_with_tags("some.distr", 4).with_sampling_rate(0.5).try_send();
+        let res = client
+            .distribution_with_tags("some.distr", 4)
+            .with_sampling_rate(0.5)
+            .try_send();
 
         assert_eq!("prefix.some.distr:4|d|@0.5", res.unwrap().as_metric_str());
     }
-
 
     #[test]
     fn test_statsd_client_set_with_tags() {

--- a/cadence/src/client.rs
+++ b/cadence/src/client.rs
@@ -676,6 +676,7 @@ pub struct StatsdClientBuilder {
     sink: Box<dyn MetricSink + Sync + Send + RefUnwindSafe>,
     errors: Box<dyn Fn(MetricError) + Sync + Send + RefUnwindSafe>,
     tags: Vec<(Option<String>, String)>,
+    container_id: Option<String>
 }
 
 impl StatsdClientBuilder {
@@ -692,6 +693,7 @@ impl StatsdClientBuilder {
             // optional with defaults
             errors: Box::new(nop_error_handler),
             tags: Vec::new(),
+            container_id: None,
         }
     }
 
@@ -730,6 +732,13 @@ impl StatsdClientBuilder {
         K: ToString,
     {
         self.tags.push((None, value.to_string()));
+        self
+    }
+
+    /// Add a default container ID to every metric published by the built
+    /// [StatsdClient].
+    pub fn with_container_id(mut self, container_id: &str) -> Self {
+        self.container_id = Some(container_id.to_string());
         self
     }
 
@@ -834,6 +843,7 @@ pub struct StatsdClient {
     sink: Box<dyn MetricSink + Sync + Send + RefUnwindSafe>,
     errors: Box<dyn Fn(MetricError) + Sync + Send + RefUnwindSafe>,
     tags: Vec<(Option<String>, String)>,
+    container_id: Option<String>,
 }
 
 impl StatsdClient {
@@ -974,6 +984,7 @@ impl StatsdClient {
             sink: builder.sink,
             errors: builder.errors,
             tags: builder.tags,
+            container_id: builder.container_id,
         }
     }
 
@@ -1016,7 +1027,9 @@ where
     fn count_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Counter> {
         match value.try_to_value() {
             Ok(v) => {
-                MetricBuilder::from_fmt(MetricFormatter::counter(&self.prefix, key, v), self).with_tags(self.tags())
+                MetricBuilder::from_fmt(MetricFormatter::counter(&self.prefix, key, v), self)
+                    .with_tags(self.tags())
+                    .with_container_id_opt(self.container_id.as_deref())
             }
             Err(e) => MetricBuilder::from_error(e, self),
         }
@@ -1031,7 +1044,9 @@ where
 {
     fn time_with_tags<'a>(&'a self, key: &'a str, time: T) -> MetricBuilder<'_, '_, Timer> {
         match time.try_to_value() {
-            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::timer(&self.prefix, key, v), self).with_tags(self.tags()),
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::timer(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1043,7 +1058,9 @@ where
 {
     fn gauge_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Gauge> {
         match value.try_to_value() {
-            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::gauge(&self.prefix, key, v), self).with_tags(self.tags()),
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::gauge(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1055,7 +1072,9 @@ where
 {
     fn meter_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Meter> {
         match value.try_to_value() {
-            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::meter(&self.prefix, key, v), self).with_tags(self.tags()),
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::meter(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1068,7 +1087,9 @@ where
     fn histogram_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Histogram> {
         match value.try_to_value() {
             Ok(v) => {
-                MetricBuilder::from_fmt(MetricFormatter::histogram(&self.prefix, key, v), self).with_tags(self.tags())
+                MetricBuilder::from_fmt(MetricFormatter::histogram(&self.prefix, key, v), self)
+                    .with_tags(self.tags())
+                    .with_container_id_opt(self.container_id.as_deref())
             }
             Err(e) => MetricBuilder::from_error(e, self),
         }
@@ -1082,7 +1103,8 @@ where
     fn distribution_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Distribution> {
         match value.try_to_value() {
             Ok(v) => MetricBuilder::from_fmt(MetricFormatter::distribution(&self.prefix, key, v), self)
-                .with_tags(self.tags()),
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1094,7 +1116,9 @@ where
 {
     fn set_with_tags<'a>(&'a self, key: &'a str, value: T) -> MetricBuilder<'_, '_, Set> {
         match value.try_to_value() {
-            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::set(&self.prefix, key, v), self).with_tags(self.tags()),
+            Ok(v) => MetricBuilder::from_fmt(MetricFormatter::set(&self.prefix, key, v), self)
+                .with_tags(self.tags())
+                .with_container_id_opt(self.container_id.as_deref()),
             Err(e) => MetricBuilder::from_error(e, self),
         }
     }
@@ -1128,6 +1152,16 @@ mod tests {
         let res = client.count("some.method", 1);
 
         assert_eq!("some.method:1|c", res.unwrap().as_metric_str());
+    }
+
+    #[test]
+    fn test_statsd_client_with_container_id() {
+        let client = StatsdClientBuilder::new("prefix", NopMetricSink)
+            .with_container_id("1234")
+            .build();
+        let res = client.count("some.method", 1);
+
+        assert_eq!("prefix.some.method:1|c|c:1234", res.unwrap().as_metric_str());
     }
 
     #[test]
@@ -1229,6 +1263,14 @@ mod tests {
         let res = client.gauge_with_tags("some.gauge", 4).try_send();
 
         assert_eq!("prefix.some.gauge:4|g|#foo:bar", res.unwrap().as_metric_str());
+    }
+
+    #[test]
+    fn test_statsd_client_gauge_with_timestamp() {
+        let client = StatsdClient::from_sink("prefix", NopMetricSink);
+        let res = client.gauge_with_tags("some.gauge", 4).with_timestamp(1234567890).try_send();
+
+        assert_eq!("prefix.some.gauge:4|g|T1234567890", res.unwrap().as_metric_str());
     }
 
     #[test]
@@ -1521,6 +1563,15 @@ mod tests {
             res.unwrap().as_metric_str()
         );
     }
+
+    #[test]
+    fn test_statsd_client_distribution_with_sampling_rate() {
+        let client = StatsdClient::from_sink("prefix", NopMetricSink);
+        let res = client.distribution_with_tags("some.distr", 4).with_sampling_rate(0.5).try_send();
+
+        assert_eq!("prefix.some.distr:4|d|@0.5", res.unwrap().as_metric_str());
+    }
+
 
     #[test]
     fn test_statsd_client_set_with_tags() {


### PR DESCRIPTION
See https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics for details

* `@<SAMPLE_RATE>` A float between 0 and 1, inclusive. Mostly important for distributions in order to get a correct `count` in the backend.
* DogStatsD protocol v1.2: Add support for container_id (`|c:<id>`)
* DogStatsD protocol v1.3: Add support for timestamps (`|T<timestamp>`)