### PR TITLE
Fix out-of-order, buffered writes

### DIFF
--- a/cadence/src/lib.rs
+++ b/cadence/src/lib.rs
@@ -510,6 +510,7 @@
 //!
 
 #![forbid(unsafe_code)]
+#![allow(clippy::uninlined_format_args)]
 
 pub const DEFAULT_PORT: u16 = 8125;
 


### PR DESCRIPTION
Out-of-order writes are possible if a large message (which exceeds buffer capacity) comes after one or more small messages (which remain in the buffer).

Issue maybe originates from/relates to
- https://github.com/56quarters/cadence/issues/59
  - https://github.com/56quarters/cadence/pull/60
- https://github.com/56quarters/cadence/issues/87
  - https://github.com/56quarters/cadence/pull/91

Provided test failed before change to fix.