### PR TITLE
Add support to re-resolve addresses periodically. Fixes #222

### DIFF
--- a/cadence/tests/core.rs
+++ b/cadence/tests/core.rs
@@ -61,5 +61,5 @@ fn test_statsd_client_histogram() {
 #[test]
 fn test_statsd_client_nop_sink_single_threaded() {
     let client = new_nop_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 1, None);
 }

--- a/cadence/tests/spy.rs
+++ b/cadence/tests/spy.rs
@@ -17,11 +17,11 @@ fn new_buffered_spy_client(prefix: &str) -> (Receiver<Vec<u8>>, StatsdClient) {
 #[test]
 fn test_statsd_client_spy_sink_single_threaded() {
     let (_rx, client) = new_spy_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 1, None);
 }
 
 #[test]
 fn test_statsd_client_buffered_spy_sink_single_threaded() {
     let (_rx, client) = new_buffered_spy_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 1, None);
 }

--- a/cadence/tests/unix.rs
+++ b/cadence/tests/unix.rs
@@ -41,7 +41,7 @@ fn test_statsd_client_unix_sink_single_threaded() {
     let harness = UnixServerHarness::new("test_statsd_client_unix_sink_single_threaded");
     harness.run_quiet(|socket| {
         let client = new_unix_client("client.test", socket);
-        run_arc_threaded_test(client, 1, 1);
+        run_arc_threaded_test(client, 1, 1, None);
     });
 }
 
@@ -50,7 +50,7 @@ fn test_statsd_client_buffered_unix_sink_single_threaded() {
     let harness = UnixServerHarness::new("test_statsd_client_buffered_unix_sink_single_threaded");
     harness.run_quiet(|socket| {
         let client = new_buffered_unix_client("client.test", socket);
-        run_arc_threaded_test(client, 1, 1);
+        run_arc_threaded_test(client, 1, 1, None);
     });
 }
 
@@ -59,6 +59,6 @@ fn test_statsd_client_queuing_buffered_unix_sink_single_threaded() {
     let harness = UnixServerHarness::new("test_statsd_client_queuing_buffered_unix_sink_single_threaded");
     harness.run_quiet(|socket| {
         let client = new_queuing_buffered_unix_client("client.test", socket);
-        run_arc_threaded_test(client, 1, 1);
+        run_arc_threaded_test(client, 1, 1, None);
     });
 }

--- a/cadence/tests/utils.rs
+++ b/cadence/tests/utils.rs
@@ -8,7 +8,12 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations: u64) {
+pub fn run_arc_threaded_test(
+    client: StatsdClient,
+    num_threads: u64,
+    iterations: u64,
+    iteration_interval: Option<Duration>,
+) {
     let shared_client = Arc::new(client);
 
     let threads: Vec<_> = (0..num_threads)
@@ -31,7 +36,7 @@ pub fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations:
                     local_client.distribution("some.distribution", i).unwrap();
                     local_client.distribution("some.distribution", i as f64).unwrap();
                     local_client.set("some.set", i as i64).unwrap();
-                    thread::sleep(Duration::from_millis(1));
+                    thread::sleep(iteration_interval.unwrap_or(Duration::from_millis(1)));
                 }
             })
         })


### PR DESCRIPTION
This PR does a couple things:

1. It adds a builder for `BufferedUdpMetricSink`. I wanted to avoid a combinatorial explosion of `with_xx` options so I added a Builder.
2. The Builder is a bit special because for `reconnect_interval` to work, `BufferedUdpMetricSink` needs ownership of the `sink_addr`. The `from` and `with_capacity` constructors don't require ownership so the builder has a private constructor that doesn't take ownership.
3. Reconnection happens whenever a write happen instead of on fixed interval. This is just so that we don't need a separate thread. 

Overall I tried to prioritize backwards compatibility while adding this feature.