### PR TITLE
feat: optionally re-resolve hosts for UDP sinks

### DIFF
--- a/cadence/README.md
+++ b/cadence/README.md
@@ -106,6 +106,43 @@ might result in the metrics being delayed for a little while until the
 buffer fills. In this case, it may make sense to use the `UdpMetricSink`
 since it does not do any buffering.
 
+### Re-resolving UDP Sinks
+
+When using UDP sinks by default, the address of the server you are
+sending metrics to is resolved a single time when the UDP sink is
+created. If you anticipate the IP address of the server you are sending
+metrics to will change, you can configure UDP sinks to periodically
+re-resolve the IP address of the metrics server. This can be done using
+their respective builders. You may also supply a function that is
+called when the re-resolution of the metrics server IP address fails.
+
+```rust
+use std::net::UdpSocket;
+use std::time::Duration;
+use cadence::prelude::*;
+use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
+
+let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+let host = ("metrics.example.com", DEFAULT_PORT);
+
+let sink = BufferedUdpMetricSink::builder()
+    .with_capacity(1024)
+    .with_resolver_period(Duration::from_secs(5))
+    .with_resolver_error_handler(|e| {
+        eprintln!("error: failed to resolve host: {}", e);
+    })
+    .build(host, socket)
+    .unwrap();
+let client = StatsdClient::from_sink("my.prefix", sink);
+
+client.count("my.counter.thing", 29);
+client.time("my.service.call", 214);
+```
+
+If enabled, periodic address resolution is done in a separate thread
+created by the sink when the sink is created. The thread is stopped
+when the sink is dropped.
+
 ### Queuing Asynchronous Metric Sink
 
 To make sure emitting metrics doesn't interfere with the performance

--- a/cadence/src/io.rs
+++ b/cadence/src/io.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::{self, WriterPanicked};
-use std::io::{BufWriter, Write};
+use std::io::{self, BufWriter, Write, WriterPanicked};
 use std::str;
 
 #[derive(Debug, Default)]

--- a/cadence/src/lib.rs
+++ b/cadence/src/lib.rs
@@ -105,6 +105,44 @@
 //! buffer fills. In this case, it may make sense to use the `UdpMetricSink`
 //! since it does not do any buffering.
 //!
+//! ### Re-resolving UDP Sinks
+//!
+//! When using UDP sinks by default, the address of the server you are
+//! sending metrics to is resolved a single time when the UDP sink is
+//! created. If you anticipate the IP address of the server you are sending
+//! metrics to will change, you can configure UDP sinks to periodically
+//! re-resolve the IP address of the metrics server. This can be done using
+//! their respective builders. You may also supply a function that is
+//! called when the re-resolution of the metrics server IP address fails.
+//!
+//! ```rust,no_run
+//! use std::net::UdpSocket;
+//! use std::time::Duration;
+//! use cadence::prelude::*;
+//! use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
+//!
+//! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+//! let host = ("metrics.example.com", DEFAULT_PORT);
+//!
+//! let sink = BufferedUdpMetricSink::builder()
+//!     .with_capacity(1024)
+//!     .with_resolver_period(Duration::from_secs(5))
+//!     .with_resolver_error_handler(|e| {
+//!         eprintln!("error: failed to resolve host: {}", e);
+//!     })
+//!     .build(host, socket)
+//!     .unwrap();
+//! let client = StatsdClient::from_sink("my.prefix", sink);
+//!
+//! client.count("my.counter.thing", 29);
+//! client.time("my.service.call", 214);
+//!
+//! ```
+//!
+//! If enabled, periodic address resolution is done in a separate thread
+//! created by the sink when the sink is created. The thread is stopped
+//! when the sink is dropped.
+//!
 //! ### Queuing Asynchronous Metric Sink
 //!
 //! To make sure emitting metrics doesn't interfere with the performance
@@ -522,8 +560,8 @@ pub use self::client::{
 };
 
 pub use self::sinks::{
-    BufferedSpyMetricSink, BufferedUdpMetricSink, MetricSink, NopMetricSink, QueuingMetricSink,
-    QueuingMetricSinkBuilder, SinkStats, SpyMetricSink, UdpMetricSink,
+    BufferedSpyMetricSink, BufferedUdpMetricSink, BufferedUdpMetricSinkBuilder, MetricSink, NopMetricSink,
+    QueuingMetricSink, QueuingMetricSinkBuilder, SinkStats, SpyMetricSink, UdpMetricSink, UdpMetricSinkBuilder,
 };
 
 pub use self::types::{

--- a/cadence/src/sinks/mod.rs
+++ b/cadence/src/sinks/mod.rs
@@ -10,13 +10,14 @@
 
 mod core;
 mod queuing;
+mod resolve;
 mod spy;
 mod udp;
 
 pub use crate::sinks::core::{MetricSink, NopMetricSink, SinkStats, SocketStats};
 pub use crate::sinks::queuing::{QueuingMetricSink, QueuingMetricSinkBuilder};
 pub use crate::sinks::spy::{BufferedSpyMetricSink, SpyMetricSink};
-pub use crate::sinks::udp::{BufferedUdpMetricSink, UdpMetricSink};
+pub use crate::sinks::udp::{BufferedUdpMetricSink, BufferedUdpMetricSinkBuilder, UdpMetricSink, UdpMetricSinkBuilder};
 
 #[cfg(unix)]
 mod unix;

--- a/cadence/src/sinks/resolve.rs
+++ b/cadence/src/sinks/resolve.rs
@@ -1,0 +1,327 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2026 Nick Pillitteri
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::types::{ErrorKind, MetricError, MetricResult};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::RwLock;
+use std::time::Duration;
+use std::{fmt, io};
+
+/// Attempt to convert anything implementing the `ToSocketAddrs` trait
+/// into a concrete `SocketAddr` instance, returning an `InvalidInput`
+/// error if the address could not be parsed.
+fn get_addr<A: ToSocketAddrs>(addr: &A) -> MetricResult<SocketAddr> {
+    match addr.to_socket_addrs()?.next() {
+        Some(addr) => Ok(addr),
+        None => Err(MetricError::from((
+            ErrorKind::InvalidInput,
+            "No socket addresses yielded",
+        ))),
+    }
+}
+
+/// Trait to get a `SocketAddr` to send metrics to, used by a
+/// `MetricSink`.
+///
+/// Different implementations allow different behavior such as only
+/// resolving hostnames when constructed or periodically re-resolving
+/// them using DNS.
+pub(crate) trait Resolver {
+    /// Get a `SocketAddr` for a metrics server.
+    ///
+    /// Implementations are expected _not_ to resolve hostnames as part of
+    /// this method call, that should be done out-of-band.
+    fn get_addr(&self) -> SocketAddr;
+
+    /// Signal that any background tasks started by the `Resolver` should
+    /// stop.
+    fn stop(&self) {}
+}
+
+/// `Resolver` implementation that does address resolution on construction
+/// only.
+#[derive(Debug)]
+pub(crate) struct StaticResolver {
+    addr: SocketAddr,
+}
+
+impl StaticResolver {
+    pub fn new<A>(name: A) -> MetricResult<Self>
+    where
+        A: ToSocketAddrs,
+    {
+        let addr = get_addr(&name)?;
+        Ok(Self { addr })
+    }
+}
+
+impl Resolver for StaticResolver {
+    fn get_addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+/// `Resolver` implementation that does address resolution on construction
+/// and periodically in the background in a separate thread.
+///
+/// The resolver does not create the thread for performing resolution in the
+/// background, the caller is expected to spawn the thread and run the `run`
+/// method in it. The `run` method will run until the `stop` method of the
+/// resolver is called.
+pub(crate) struct PeriodicResolver<A, E, S>
+where
+    A: ToSocketAddrs + fmt::Debug,
+    E: Fn(io::Error),
+    S: Fn(Duration),
+{
+    name: A,
+    errors: E,
+    sleep: S,
+    addr: RwLock<SocketAddr>,
+    period: Duration,
+    run: AtomicBool,
+    stopped: AtomicBool,
+    successes: AtomicU64,
+    failures: AtomicU64,
+}
+
+impl<A, E, S> PeriodicResolver<A, E, S>
+where
+    A: ToSocketAddrs + fmt::Debug,
+    E: Fn(io::Error),
+    S: Fn(Duration),
+{
+    pub(crate) fn new(name: A, period: Duration, errors: E, sleep: S) -> MetricResult<Self> {
+        let addr = get_addr(&name)?;
+
+        Ok(Self {
+            addr: RwLock::new(addr),
+            run: AtomicBool::new(true),
+            stopped: AtomicBool::new(false),
+            successes: AtomicU64::new(0),
+            failures: AtomicU64::new(0),
+            name,
+            errors,
+            sleep,
+            period,
+        })
+    }
+
+    pub(crate) fn run(&self) {
+        while self.run.load(Ordering::Acquire) {
+            (self.sleep)(self.period);
+
+            let addr = match self.name.to_socket_addrs().map(|mut i| i.next()) {
+                Ok(Some(v)) => v,
+                Ok(None) => {
+                    self.incr_failures();
+                    (self.errors)(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("{:?} did not resolve to any addresses", self.name),
+                    ));
+                    continue;
+                }
+                Err(e) => {
+                    self.incr_failures();
+                    (self.errors)(e);
+                    continue;
+                }
+            };
+
+            self.incr_success();
+            *self.addr.write().unwrap() = addr;
+        }
+
+        self.stopped.store(true, Ordering::Release);
+    }
+
+    fn incr_success(&self) -> u64 {
+        self.successes.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn successes(&self) -> u64 {
+        self.successes.load(Ordering::Relaxed)
+    }
+
+    fn incr_failures(&self) -> u64 {
+        self.failures.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn failures(&self) -> u64 {
+        self.failures.load(Ordering::Relaxed)
+    }
+}
+
+impl<A, E, S> fmt::Debug for PeriodicResolver<A, E, S>
+where
+    A: ToSocketAddrs + fmt::Debug,
+    E: Fn(io::Error),
+    S: Fn(Duration),
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PeriodicResolver")
+            .field("name", &self.name)
+            .field("period", &self.period)
+            .finish()
+    }
+}
+
+impl<A, E, S> Resolver for PeriodicResolver<A, E, S>
+where
+    A: ToSocketAddrs + fmt::Debug,
+    E: Fn(io::Error),
+    S: Fn(Duration),
+{
+    fn get_addr(&self) -> SocketAddr {
+        *self.addr.read().unwrap()
+    }
+
+    fn stop(&self) {
+        self.run.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PeriodicResolver, Resolver};
+    use crate::types::ErrorKind;
+    use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::{io, thread, vec};
+
+    #[test]
+    fn test_periodic_resolver_initial_resolution_fails() {
+        let err = PeriodicResolver::new("invalid:invalid", Duration::from_secs(1), |_e| {}, |_d| {}).unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_periodic_resolver_initial_resolution_succeeds() {
+        let resolver = PeriodicResolver::new("127.0.0.1:8125", Duration::from_secs(1), |_e| {}, |_d| {}).unwrap();
+        let expected = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 8125));
+        assert_eq!(expected, resolver.get_addr());
+    }
+
+    #[derive(Debug)]
+    struct FailingAddr {
+        name: String,
+        successes: u64,
+        count: AtomicU64,
+    }
+
+    impl FailingAddr {
+        fn new<S>(name: S, successes: u64) -> Self
+        where
+            S: Into<String>,
+        {
+            Self {
+                name: name.into(),
+                count: AtomicU64::new(0),
+                successes,
+            }
+        }
+    }
+
+    impl ToSocketAddrs for FailingAddr {
+        type Iter = vec::IntoIter<SocketAddr>;
+
+        fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
+            self.count.fetch_add(1, Ordering::Relaxed);
+
+            if self.count.load(Ordering::Relaxed) <= self.successes {
+                self.name.to_socket_addrs()
+            } else {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, "test lookup failed"))
+            }
+        }
+    }
+
+    #[test]
+    fn test_periodic_resolver_periodic_resolution_fails() {
+        // Zero capacity channels so that send/recv calls block until the corresponding
+        // call is made in another thread. This allows us to enter the main "run" loop,
+        // pause, and then only proceed after the "run" loop has been stopped from another
+        // thread ensuring we get a single iteration.
+        let (run_tx, run_rx) = crossbeam_channel::bounded(0);
+        let (done_tx, done_rx) = crossbeam_channel::bounded(0);
+
+        let sleep = move |_d: Duration| {
+            run_rx.recv().unwrap();
+            done_tx.send(()).unwrap();
+        };
+
+        let error_count = Arc::new(AtomicU64::new(0));
+        let error_count_c = error_count.clone();
+        let errors = move |_e| {
+            error_count_c.fetch_add(1, Ordering::Relaxed);
+        };
+
+        // This address will return results for the first (initial) call to
+        // `to_socket_addrs` but fail during the periodic re-resolve that the
+        // resolver attempts.
+        let addr = FailingAddr::new("127.0.0.1:8125", 1);
+
+        let resolver = Arc::new(PeriodicResolver::new(addr, Duration::from_secs(1), errors, sleep).unwrap());
+        let resolver_c = resolver.clone();
+
+        let t1 = thread::spawn(move || {
+            run_tx.send(()).unwrap();
+            resolver_c.stop();
+            done_rx.recv().unwrap();
+        });
+
+        resolver.run();
+        let _ = t1.join();
+
+        let expected = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 8125));
+        assert_eq!(expected, resolver.get_addr());
+        assert_eq!(0, resolver.successes());
+        assert_eq!(1, resolver.failures());
+        assert_eq!(1, error_count.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_periodic_resolver_periodic_resolution_succeeds() {
+        // Zero capacity channels so that send/recv calls block until the corresponding
+        // call is made in another thread. This allows us to enter the main "run" loop,
+        // pause, and then only proceed after the "run" loop has been stopped from another
+        // thread ensuring we get a single iteration.
+        let (run_tx, run_rx) = crossbeam_channel::bounded(0);
+        let (done_tx, done_rx) = crossbeam_channel::bounded(0);
+
+        let sleep = move |_d: Duration| {
+            run_rx.recv().unwrap();
+            done_tx.send(()).unwrap();
+        };
+
+        let resolver =
+            Arc::new(PeriodicResolver::new("127.0.0.1:8125", Duration::from_secs(1), |_e| {}, sleep).unwrap());
+        let resolver_c1 = resolver.clone();
+
+        let t1 = thread::spawn(move || {
+            run_tx.send(()).unwrap();
+            resolver_c1.stop();
+            done_rx.recv().unwrap();
+        });
+
+        resolver.run();
+        let _ = t1.join();
+
+        let expected = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 8125));
+        assert_eq!(expected, resolver.get_addr());
+        assert_eq!(1, resolver.successes());
+        assert_eq!(0, resolver.failures());
+    }
+}

--- a/cadence/src/sinks/udp.rs
+++ b/cadence/src/sinks/udp.rs
@@ -8,14 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
-use std::io::Write;
-use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::Mutex;
-
 use crate::io::MultiLineWriter;
 use crate::sinks::core::{MetricSink, SinkStats, SocketStats};
-use crate::types::{ErrorKind, MetricError, MetricResult};
+use crate::sinks::resolve::{PeriodicResolver, Resolver, StaticResolver};
+use crate::types::MetricResult;
+use std::io::{self, Write};
+use std::net::{ToSocketAddrs, UdpSocket};
+use std::panic::RefUnwindSafe;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::{fmt, thread};
 
 // Default size of the buffer for buffered metric sinks. This
 // is a rather conservative value, picked to make sure the entire
@@ -24,19 +26,123 @@ use crate::types::{ErrorKind, MetricError, MetricResult};
 // their application runs in.
 const DEFAULT_BUFFER_SIZE: usize = 512;
 
-/// Attempt to convert anything implementing the `ToSocketAddrs` trait
-/// into a concrete `SocketAddr` instance, returning an `InvalidInput`
-/// error if the address could not be parsed.
-// Public portion of the API (the sink constructors) is pass by value so
-// there's no point in changing this to be pass by reference yet.
-#[allow(clippy::needless_pass_by_value)]
-fn get_addr<A: ToSocketAddrs>(addr: A) -> MetricResult<SocketAddr> {
-    match addr.to_socket_addrs()?.next() {
-        Some(addr) => Ok(addr),
-        None => Err(MetricError::from((
-            ErrorKind::InvalidInput,
-            "No socket addresses yielded",
-        ))),
+/// Create a new shared `Resolver` implementation for the given
+/// address based on if a refresh has been set.
+///
+/// An error is returned if the initial resolution of `addr` fails.
+fn get_resolver<A>(
+    addr: A,
+    period: Option<Duration>,
+    error_handler: Option<Box<dyn Fn(io::Error) + Sync + Send + RefUnwindSafe>>,
+) -> MetricResult<Arc<dyn Resolver + Send + Sync + RefUnwindSafe>>
+where
+    A: ToSocketAddrs + fmt::Debug + Send + Sync + RefUnwindSafe + 'static,
+{
+    match period {
+        Some(duration) => {
+            let error_handler = error_handler.unwrap_or_else(|| Box::new(|_e| {}));
+            let sleep = |d| thread::sleep(d);
+            let resolver = Arc::new(PeriodicResolver::new(addr, duration, error_handler, sleep)?);
+            let resolver_c = resolver.clone();
+            crate::sync::execute(move || resolver_c.run());
+            Ok(resolver)
+        }
+        None => Ok(Arc::new(StaticResolver::new(addr)?)),
+    }
+}
+
+/// Implementation of a builder pattern for `UdpMetricSink`.
+///
+/// The builder can be used to set how often the hostname to send
+/// metrics to is re-resolved via DNS and how to handle errors when
+/// re-resolving the hostname. If these options are _not_ set, the
+/// default behavior is to only resolve the hostname for sending
+/// metrics upon creation of the sink, the same as when the sink
+/// is created using `UdpMetricSink::from()`.
+///
+/// When the option to re-resolve hostnames to send metrics to is
+/// enabled, a new thread is spawned when the sink is created that
+/// will run until the sink is dropped, updating the `SocketAddr`
+/// used for sending metrics in the background.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::net::UdpSocket;
+/// use std::time::Duration;
+/// use cadence::{UdpMetricSink, DEFAULT_PORT};
+///
+/// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+/// let host = ("metrics.example.com", DEFAULT_PORT);
+/// let sink = UdpMetricSink::builder()
+///     .with_resolver_period(Duration::from_secs(5))
+///     .with_resolver_error_handler(|e| {
+///         eprintln!("failed to re-resolve address: {}", e);
+///     })
+///     .build(host, socket)
+///     .unwrap();
+/// ```
+#[derive(Default)]
+pub struct UdpMetricSinkBuilder {
+    resolver_period: Option<Duration>,
+    resolver_error_handler: Option<Box<dyn Fn(io::Error) + Sync + Send + RefUnwindSafe>>,
+}
+
+impl UdpMetricSinkBuilder {
+    /// Construct a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a new `UdpMetricSink` instance that emits metrics
+    /// using the provided address and socket.
+    ///
+    /// The `UdpMetricSink` may optionally re-resolve the provided
+    /// address using DNS periodically. If provided, an error handler
+    /// will be invoked when the address cannot be resolved. The
+    /// error handler runs in the same thread as the resolver logic,
+    /// different from the thread the sink runs in, and must not
+    /// panic.
+    ///
+    /// # Failures
+    ///
+    /// This method may fail if:
+    ///
+    /// * It is unable to resolve the hostname of the metric server.
+    /// * The host address is otherwise unable to be parsed
+    pub fn build<A>(self, to_addr: A, socket: UdpSocket) -> MetricResult<UdpMetricSink>
+    where
+        A: ToSocketAddrs + fmt::Debug + Send + Sync + RefUnwindSafe + 'static,
+    {
+        let resolver = get_resolver(to_addr, self.resolver_period, self.resolver_error_handler)?;
+        let stats = SocketStats::default();
+        Ok(UdpMetricSink {
+            resolver,
+            socket,
+            stats,
+        })
+    }
+
+    /// Set how often to re-resolve the metric server address for this sink.
+    ///
+    /// If not called, the metric server address is only resolved once when the
+    /// sink is constructed.
+    pub fn with_resolver_period(mut self, duration: Duration) -> Self {
+        self.resolver_period = Some(duration);
+        self
+    }
+
+    /// Set the error handler to use when re-resolving the metric server address
+    /// fails.
+    ///
+    /// If `with_resolver_period` has not been called before the sink is constructed,
+    /// the error handler is not used.
+    pub fn with_resolver_error_handler<F>(mut self, error_handler: F) -> Self
+    where
+        F: Fn(io::Error) + Sync + Send + RefUnwindSafe + 'static,
+    {
+        self.resolver_error_handler = Some(Box::new(error_handler));
+        self
     }
 }
 
@@ -48,14 +154,39 @@ fn get_addr<A: ToSocketAddrs>(addr: A) -> MetricResult<SocketAddr> {
 ///
 /// Each metric is sent to the Statsd server when the `.emit()` method is
 /// called, in the thread of the caller.
-#[derive(Debug)]
 pub struct UdpMetricSink {
-    addr: SocketAddr,
+    resolver: Arc<dyn Resolver + Send + Sync + RefUnwindSafe>,
     socket: UdpSocket,
     stats: SocketStats,
 }
 
 impl UdpMetricSink {
+    /// Construct a new builder for `UdpMetricSink` that can be used to
+    /// customize advanced behavior of the sink.
+    ///
+    /// See `UdpMetricSinkBuilder` for more information.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    /// use std::time::Duration;
+    /// use cadence::{UdpMetricSink, DEFAULT_PORT};
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    /// let host = ("metrics.example.com", DEFAULT_PORT);
+    /// let sink = UdpMetricSink::builder()
+    ///     .with_resolver_period(Duration::from_secs(5))
+    ///     .with_resolver_error_handler(|e| {
+    ///         eprintln!("failed to re-resolve address: {}", e);
+    ///     })
+    ///     .build(host, socket)
+    ///     .unwrap();
+    /// ```
+    pub fn builder() -> UdpMetricSinkBuilder {
+        UdpMetricSinkBuilder::new()
+    }
+
     /// Construct a new `UdpMetricSink` instance.
     ///
     /// The address should be the address of the remote metric server to
@@ -79,10 +210,6 @@ impl UdpMetricSink {
     ///
     /// # Non-blocking Example
     ///
-    /// Note that putting the UDP socket into non-blocking mode is the
-    /// default when sink and socket are automatically created with the
-    /// `StatsdClient::from_udp_host` method.
-    ///
     /// ```no_run
     /// use std::net::UdpSocket;
     /// use cadence::{UdpMetricSink, DEFAULT_PORT};
@@ -90,7 +217,7 @@ impl UdpMetricSink {
     /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     /// socket.set_nonblocking(true).unwrap();
     /// let host = ("metrics.example.com", DEFAULT_PORT);
-    /// let sink = UdpMetricSink::from(host, socket);
+    /// let sink = UdpMetricSink::from(host, socket).unwrap();
     /// ```
     ///
     /// # Failures
@@ -99,20 +226,27 @@ impl UdpMetricSink {
     ///
     /// * It is unable to resolve the hostname of the metric server.
     /// * The host address is otherwise unable to be parsed
-    pub fn from<A>(to_addr: A, socket: UdpSocket) -> MetricResult<UdpMetricSink>
+    pub fn from<A>(to_addr: A, socket: UdpSocket) -> MetricResult<Self>
     where
         A: ToSocketAddrs,
     {
-        let addr = get_addr(to_addr)?;
+        // TODO: Explain the bounds of A
+        let resolver = Arc::new(StaticResolver::new(to_addr)?);
         let stats = SocketStats::default();
-        Ok(UdpMetricSink { addr, socket, stats })
+        Ok(Self {
+            resolver,
+            socket,
+            stats,
+        })
     }
 }
 
 impl MetricSink for UdpMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
-        self.stats
-            .update(self.socket.send_to(metric.as_bytes(), self.addr), metric.len())
+        self.stats.update(
+            self.socket.send_to(metric.as_bytes(), self.resolver.get_addr()),
+            metric.len(),
+        )
     }
 
     fn stats(&self) -> SinkStats {
@@ -120,27 +254,176 @@ impl MetricSink for UdpMetricSink {
     }
 }
 
+impl Drop for UdpMetricSink {
+    fn drop(&mut self) {
+        self.resolver.stop();
+    }
+}
+
+impl fmt::Debug for UdpMetricSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UdpMetricSink")
+            .field("resolver", &"...")
+            .field("socket", &self.socket)
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
 /// Adapter for writing to a `UdpSocket` via the `Write` trait
-#[derive(Debug)]
 pub(crate) struct UdpWriteAdapter {
-    addr: SocketAddr,
+    resolver: Arc<dyn Resolver + Send + Sync + RefUnwindSafe>,
     socket: UdpSocket,
     stats: SocketStats,
 }
 
 impl UdpWriteAdapter {
-    pub(crate) fn new(addr: SocketAddr, socket: UdpSocket, stats: SocketStats) -> UdpWriteAdapter {
-        UdpWriteAdapter { addr, socket, stats }
+    pub(crate) fn new(
+        resolver: Arc<dyn Resolver + Send + Sync + RefUnwindSafe>,
+        socket: UdpSocket,
+        stats: SocketStats,
+    ) -> Self {
+        Self {
+            resolver,
+            socket,
+            stats,
+        }
     }
 }
 
 impl Write for UdpWriteAdapter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.stats.update(self.socket.send_to(buf, self.addr), buf.len())
+        self.stats
+            .update(self.socket.send_to(buf, self.resolver.get_addr()), buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+impl Drop for UdpWriteAdapter {
+    fn drop(&mut self) {
+        self.resolver.stop();
+    }
+}
+
+impl fmt::Debug for UdpWriteAdapter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UdpWriteAdapter")
+            .field("resolver", &"...")
+            .field("socket", &self.socket)
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+/// Implementation of a builder pattern for `BufferedUdpMetricSink`.
+///
+/// The builder can be used to set the capacity of the buffer, how
+/// often the hostname to send metrics to is re-resolved via DNS, and
+/// how to handle errors when re-resolving the hostname. If these
+/// options are _not_ set, the default behavior is to only resolve
+/// the hostname for sending metrics upon creation of the sink and
+/// use a default buffer size, the same as when the sink is created
+/// using `BufferedUdpMetricSink::from()`.
+///
+/// When the option to re-resolve hostnames to send metrics to is
+/// enabled, a new thread is spawned when the sink is created that
+/// will run until the sink is dropped, updating the `SocketAddr`
+/// used for sending metrics in the background.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::net::UdpSocket;
+/// use std::time::Duration;
+/// use cadence::{BufferedUdpMetricSink, DEFAULT_PORT};
+///
+/// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+/// let host = ("metrics.example.com", DEFAULT_PORT);
+/// let sink = BufferedUdpMetricSink::builder()
+///     .with_capacity(1024)
+///     .with_resolver_period(Duration::from_secs(5))
+///     .with_resolver_error_handler(|e| {
+///         eprintln!("failed to re-resolve address: {}", e);
+///     })
+///     .build(host, socket)
+///     .unwrap();
+/// ```
+#[derive(Default)]
+pub struct BufferedUdpMetricSinkBuilder {
+    capacity: Option<usize>,
+    resolver_period: Option<Duration>,
+    resolver_error_handler: Option<Box<dyn Fn(io::Error) + Sync + Send + RefUnwindSafe>>,
+}
+
+impl BufferedUdpMetricSinkBuilder {
+    /// Construct a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a new `BufferedUdpMetricSink` instance that emits metrics
+    /// using the provided address and socket.
+    ///
+    /// The `BufferedUdpMetricSink` may optionally re-resolve the provided
+    /// address using DNS periodically. If provided, an error handler
+    /// will be invoked when the address cannot be resolved. The
+    /// error handler runs in the same thread as the resolver logic,
+    /// different from the thread the sink runs in, and must not
+    /// panic.
+    ///
+    /// # Failures
+    ///
+    /// This method may fail if:
+    ///
+    /// * It is unable to resolve the hostname of the metric server.
+    /// * The host address is otherwise unable to be parsed
+    pub fn build<A>(self, to_addr: A, socket: UdpSocket) -> MetricResult<BufferedUdpMetricSink>
+    where
+        A: ToSocketAddrs + fmt::Debug + Send + Sync + RefUnwindSafe + 'static,
+    {
+        let resolver = get_resolver(to_addr, self.resolver_period, self.resolver_error_handler)?;
+        let stats = SocketStats::default();
+        Ok(BufferedUdpMetricSink {
+            buffer: Mutex::new(MultiLineWriter::new(
+                UdpWriteAdapter::new(resolver, socket, stats.clone()),
+                self.capacity.unwrap_or(DEFAULT_BUFFER_SIZE),
+            )),
+            stats,
+        })
+    }
+
+    /// Set the capacity of the buffer used for metrics before sending
+    /// them to underlying socket.
+    ///
+    /// If not called, the default buffer size (512 bytes) is used.
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
+    }
+
+    /// Set how often to re-resolve the metric server address for this sink.
+    ///
+    /// If not called, the metric server address is only resolved once when the
+    /// sink is constructed.
+    pub fn with_resolver_period(mut self, duration: Duration) -> Self {
+        self.resolver_period = Some(duration);
+        self
+    }
+
+    /// Set the error handler to use when re-resolving the metric server address
+    /// fails.
+    ///
+    /// If `with_resolver_period` has not been called before the sink is constructed,
+    /// the error handler is not used.
+    pub fn with_resolver_error_handler<F>(mut self, error_handler: F) -> Self
+    where
+        F: Fn(io::Error) + Sync + Send + RefUnwindSafe + 'static,
+    {
+        self.resolver_error_handler = Some(Box::new(error_handler));
+        self
     }
 }
 
@@ -203,7 +486,7 @@ impl BufferedUdpMetricSink {
     ///
     /// * It is unable to resolve the hostname of the metric server.
     /// * The host address is otherwise unable to be parsed
-    pub fn from<A>(sink_addr: A, socket: UdpSocket) -> MetricResult<BufferedUdpMetricSink>
+    pub fn from<A>(sink_addr: A, socket: UdpSocket) -> MetricResult<Self>
     where
         A: ToSocketAddrs,
     {
@@ -242,19 +525,45 @@ impl BufferedUdpMetricSink {
     ///
     /// * It is unable to resolve the hostname of the metric server.
     /// * The host address is otherwise unable to be parsed
-    pub fn with_capacity<A>(sink_addr: A, socket: UdpSocket, cap: usize) -> MetricResult<BufferedUdpMetricSink>
+    pub fn with_capacity<A>(to_addr: A, socket: UdpSocket, cap: usize) -> MetricResult<Self>
     where
         A: ToSocketAddrs,
     {
-        let addr = get_addr(sink_addr)?;
+        let resolver = Arc::new(StaticResolver::new(to_addr)?);
         let stats = SocketStats::default();
         Ok(BufferedUdpMetricSink {
             buffer: Mutex::new(MultiLineWriter::new(
-                UdpWriteAdapter::new(addr, socket, stats.clone()),
+                UdpWriteAdapter::new(resolver, socket, stats.clone()),
                 cap,
             )),
             stats,
         })
+    }
+
+    /// Construct a new builder for `BufferedUdpMetricSink` that can be used to
+    /// customize advanced behavior of the sink.
+    ///
+    /// See `BufferedUdpMetricSinkBuilder` for more information.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    /// use std::time::Duration;
+    /// use cadence::{BufferedUdpMetricSink, DEFAULT_PORT};
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    /// let host = ("metrics.example.com", DEFAULT_PORT);
+    /// let sink = BufferedUdpMetricSink::builder()
+    ///     .with_resolver_period(Duration::from_secs(5))
+    ///     .with_resolver_error_handler(|e| {
+    ///         eprintln!("failed to re-resolve address: {}", e);
+    ///     })
+    ///     .build(host, socket)
+    ///     .unwrap();
+    /// ```
+    pub fn builder() -> BufferedUdpMetricSinkBuilder {
+        BufferedUdpMetricSinkBuilder::new()
     }
 }
 
@@ -276,20 +585,8 @@ impl MetricSink for BufferedUdpMetricSink {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_addr, BufferedUdpMetricSink, MetricSink, UdpMetricSink};
+    use super::{BufferedUdpMetricSink, MetricSink, UdpMetricSink};
     use std::net::UdpSocket;
-
-    #[test]
-    fn test_get_addr_bad_address() {
-        let res = get_addr("asdf");
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn test_get_addr_valid_address() {
-        let res = get_addr("127.0.0.1:8125");
-        assert!(res.is_ok());
-    }
 
     #[test]
     fn test_udp_metric_sink() {

--- a/cadence/src/sync.rs
+++ b/cadence/src/sync.rs
@@ -15,7 +15,7 @@ use std::thread;
 
 /// Statistics about the job being run by the `execute` method.
 #[derive(Debug, Default)]
-pub struct ExecuteStats {
+pub(crate) struct ExecuteStats {
     panics: AtomicU64,
 }
 
@@ -34,7 +34,7 @@ impl ExecuteStats {
 ///
 /// Since a new thread is created for each task executed, this should only be used for
 /// long-running tasks.
-pub fn execute<F>(f: F) -> Arc<ExecuteStats>
+pub(crate) fn execute<F>(f: F) -> Arc<ExecuteStats>
 where
     F: Fn() + Send + Sync + RefUnwindSafe + 'static,
 {


### PR DESCRIPTION
Add builders for UDP sinks (`UdpMetricSink` and `BufferedUdpMetricSink`) that allow a "resolver_period" option to be set. This option will re-resolve the original hostname provided to the sink and update the address for sending metrics.

Fixes #222