### PR TITLE
Use resolving behavior in integration tests

### DIFF
--- a/cadence/examples/resolving-udp-sink.rs
+++ b/cadence/examples/resolving-udp-sink.rs
@@ -1,0 +1,43 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// To the extent possible under law, the author(s) have dedicated all copyright and
+// related and neighboring rights to this file to the public domain worldwide.
+// This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication along with this
+// software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+// This example shows using a UDP sink that automatically re-resolves the address
+// of the server periodically.
+
+use cadence::prelude::*;
+use cadence::{BufferedUdpMetricSink, StatsdClient, DEFAULT_PORT};
+use std::net::UdpSocket;
+use std::time::Duration;
+
+fn main() {
+    let sock = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let sink = BufferedUdpMetricSink::builder()
+        .with_capacity(128)
+        .with_resolver_period(Duration::from_millis(100))
+        .with_resolver_error_handler(|e| {
+            eprintln!("failed to resolve server: {}", e);
+        })
+        .build(("localhost", DEFAULT_PORT), sock)
+        .unwrap();
+
+    let client = StatsdClient::from_sink("example.prefix", sink);
+
+    client.count("example.counter", 1).unwrap();
+    client.gauge("example.gauge", 5).unwrap();
+    client.gauge("example.gauge", 5.0).unwrap();
+    client.time("example.timer", 32).unwrap();
+    client.time("example.timer", Duration::from_millis(32)).unwrap();
+    client.histogram("example.histogram", 22).unwrap();
+    client.histogram("example.histogram", Duration::from_nanos(22)).unwrap();
+    client.histogram("example.histogram", 22.0).unwrap();
+    client.distribution("example.distribution", 33).unwrap();
+    client.distribution("example.distribution", 33.0).unwrap();
+    client.meter("example.meter", 8).unwrap();
+    client.set("example.set", 44).unwrap();
+}

--- a/cadence/tests/udp.rs
+++ b/cadence/tests/udp.rs
@@ -1,5 +1,6 @@
 use cadence::{BufferedUdpMetricSink, QueuingMetricSink, StatsdClient, UdpMetricSink, DEFAULT_PORT};
 use std::net::UdpSocket;
+use std::time::Duration;
 use utils::run_arc_threaded_test;
 
 mod utils;
@@ -8,7 +9,11 @@ const TARGET_HOST: (&str, u16) = ("127.0.0.1", DEFAULT_PORT);
 
 fn new_udp_client(prefix: &str) -> StatsdClient {
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let sink = UdpMetricSink::from(TARGET_HOST, socket).unwrap();
+    let sink = UdpMetricSink::builder()
+        .with_resolver_period(Duration::from_millis(100))
+        .with_resolver_error_handler(|e| panic!("resolve error: {}", e))
+        .build(TARGET_HOST, socket)
+        .unwrap();
     StatsdClient::from_sink(prefix, sink)
 }
 
@@ -28,17 +33,17 @@ fn new_queuing_buffered_udp_client(prefix: &str) -> StatsdClient {
 #[test]
 fn test_statsd_client_udp_sink_single_threaded() {
     let client = new_udp_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 10);
 }
 
 #[test]
 fn test_statsd_client_buffered_udp_sink_single_threaded() {
     let client = new_buffered_udp_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 10);
 }
 
 #[test]
 fn test_statsd_client_queuing_buffered_udp_sink_single_threaded() {
     let client = new_queuing_buffered_udp_client("cadence");
-    run_arc_threaded_test(client, 1, 1);
+    run_arc_threaded_test(client, 1, 10);
 }


### PR DESCRIPTION
This changes the UDP sinks in integration test to use the re-resolving behavior. Also add an example of how to configure sinks to use this in the examples directory.

Related #236 #222